### PR TITLE
allow meta/ctrl click on sidebar links

### DIFF
--- a/packages/ladle/lib/app/src/sidebar/tree-view.tsx
+++ b/packages/ladle/lib/app/src/sidebar/tree-view.tsx
@@ -190,9 +190,10 @@ const NavigationSection: React.FC<{
                   href={getHref({ story: treeProps.id })}
                   onKeyDown={(e) => onKeyDownFn(e, treeProps)}
                   onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    updateStory(treeProps.id);
+                    if (!e.ctrlKey && !e.metaKey) {
+                      e.preventDefault();
+                      updateStory(treeProps.id);
+                    }
                   }}
                 >
                   {treeProps.name}


### PR DESCRIPTION
Currently, command/control click on sidebar links (to open page in a new tab) is broken due to how the default click event behavior is disabled. This makes for a good same-tab experience so that users don't get a page-load flash and can load quickly. This change checks for if the meta/ctrl keys are pressed and will fallback to browser controls