### PR TITLE
feat: support publicDir from vite

### DIFF
--- a/packages/ladle/lib/cli/vite-base.js
+++ b/packages/ladle/lib/cli/vite-base.js
@@ -1,9 +1,24 @@
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join } from "path";
 import { fileURLToPath } from "url";
 import path from "path";
 import react from "@vitejs/plugin-react";
 import ladlePlugin from "./vite-plugin/vite-plugin.js";
 import { flowPlugin, esbuildFlowPlugin } from "./strip-flow.js";
+
+/**
+ * @param publicDir {string | false}
+ */
+const getPublicDir = (publicDir) => {
+  if (!publicDir) {
+    return false;
+  }
+
+  if (isAbsolute(publicDir)) {
+    return publicDir;
+  }
+
+  return join(process.cwd(), publicDir || "public");
+};
 
 /**
  * @param ladleConfig {import("../shared/types").Config}
@@ -19,10 +34,7 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
     ...viteConfig,
     configFile: false,
     root: join(__dirname, "../app/"),
-    publicDir:
-      ladleConfig.publicDir === false
-        ? ladleConfig.publicDir
-        : join(process.cwd(), ladleConfig.publicDir || 'public'),
+    publicDir: getPublicDir(ladleConfig.publicDir),
     base: ladleConfig.build.baseUrl,
     define: {
       ...(ladleConfig.define ? ladleConfig.define : {}),

--- a/packages/ladle/lib/cli/vite-base.js
+++ b/packages/ladle/lib/cli/vite-base.js
@@ -19,6 +19,10 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
     ...viteConfig,
     configFile: false,
     root: join(__dirname, "../app/"),
+    publicDir:
+      ladleConfig.publicDir === false
+        ? ladleConfig.publicDir
+        : join(process.cwd(), ladleConfig.publicDir || 'public'),
     base: ladleConfig.build.baseUrl,
     define: {
       ...(ladleConfig.define ? ladleConfig.define : {}),

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -1,7 +1,7 @@
 import path from "path";
 
 let root = "/";
-let publicDir;
+let publicDir = "public";
 
 try {
   root = process.cwd();

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -1,6 +1,11 @@
+import path from "path";
+
 let root = "/";
+let publicDir;
+
 try {
   root = process.cwd();
+  publicDir = path.join(process.cwd(), "public");
 } catch (e) {}
 
 /**
@@ -9,6 +14,7 @@ try {
 export default {
   stories: "src/**/*.stories.{js,jsx,ts,tsx}",
   root,
+  publicDir,
   defaultStory: "", // default story id to load, alphabetical by default
   babelPresets: [],
   babelPlugins: [],

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -139,6 +139,7 @@ export type PluginOptions = {
 export type Config = {
   stories: string;
   root: string;
+  publicDir?: string | false;
   defaultStory: string;
   babelPlugins: any[];
   babelPresets: any[];

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -139,7 +139,7 @@ export type PluginOptions = {
 export type Config = {
   stories: string;
   root: string;
-  publicDir?: string | false;
+  publicDir: string | false;
   defaultStory: string;
   babelPlugins: any[];
   babelPresets: any[];

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -58,6 +58,7 @@ All settings you can change and their details:
 export default {
   stories: "src/**/*.stories.{js,jsx,ts,tsx}",
   root: "./",
+  publicDir: "public", // can be an absolute path or `false` to disable the feature
   defaultStory: "", // default story id to load, alphabetical by default
   babelPresets: [],
   babelPlugins: [],


### PR DESCRIPTION
Hi! 👋🏽 

I found this package today and started to evaluate it as a replacement for Storybook.
During my first look at it, I didn't find a way to serve files statically like the `-s, --static-dir` in Storybook.

`vite` has the [`publicDir` config option]((https://vitejs.dev/config/#publicdir)), currently not supported.
It defaults to `public` but it can be `false` to disable the behaviour.

The `root` directory for `ladle` is inside the `node_modules` folder.
Therefore, I used the `process.cwd()` to figure the absolute path.
With this, users can use only `publicDir: 'myFolder'` as in `vite` itself.

❗ I'll work on a documentation update tomorrow but decided to open the PR for feedback.

If you have any opinions or suggestions about this change, let me know below.