### PR TITLE
feat: add support for components.ts and components.jsx in getComponents util

### DIFF
--- a/packages/website/docs/providers.md
+++ b/packages/website/docs/providers.md
@@ -3,7 +3,7 @@ id: providers
 title: Providers
 ---
 
-Your components might need some global [React Context Provider](https://reactjs.org/docs/context.html#contextprovider). This is typically used for localization, state sharing or routing. You can add a provider to individual stories through [decorators](./stories#decorators). However, you can also create a global provider by adding `.ladle/components.tsx` (or `.js`):
+Your components might need some global [React Context Provider](https://reactjs.org/docs/context.html#contextprovider). This is typically used for localization, state sharing or routing. You can add a provider to individual stories through [decorators](./stories#decorators). However, you can also create a global provider by adding `.ladle/components.tsx` (or `.ts`, `.jsx`, or `.js`):
 
 ```tsx
 import type { GlobalProvider } from "@ladle/react";


### PR DESCRIPTION
Adds support for `components.ts` and `components.jsx`, making it far easier to e.g. use JavaScript React.

Reduces I/O operations - especially if multiple `components.{js,jsx,ts,tsx}` are found.