### PR TITLE
feat(ladle/cli): support lazily import Vite plugins

### DIFF
--- a/packages/ladle/lib/cli/vite-base.js
+++ b/packages/ladle/lib/cli/vite-base.js
@@ -38,6 +38,18 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
     reactAlias["react-dom/client"] = "react-dom";
   }
 
+  const userVitePlugins = (
+    await Promise.all(
+      ladleConfig.vitePlugins.map(async (plugin) => {
+        if (typeof plugin === "function") {
+          return plugin();
+        } else {
+          return plugin;
+        }
+      }),
+    )
+  ).filter((v) => !!v);
+
   /**
    * @type {import('vite').InlineConfig}
    */
@@ -107,7 +119,7 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
         },
       }),
       ...(viteConfig.plugins ? viteConfig.plugins : []),
-      ...ladleConfig.vitePlugins,
+      ...userVitePlugins,
     ],
     ...(ladleConfig.enableFlow
       ? {

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -138,6 +138,31 @@ export type PluginOptions = {
   configFolder: string;
 };
 
+/**
+ * We accept not only the normal {@link Plugin} but also
+ * the conditional function that returns {@link Plugin} or `null`.
+ * Therefore, we can have a plugin that is conditionally enabled or disabled:
+ *
+ * ```js
+ * {
+ *   vitePlugins: [
+ *     // The normal plugin.
+ *     plugin(),
+ *
+ *     // The plugin that is returned by a function.
+ *     () => process.env.ENABLE_PLUGIN === '1' && plugin(),
+ *
+ *     // The plugin that is returned by an asynchronous function.
+ *     () => import('vite-plugin').then(({ default: plugin }) => plugin()),
+ *   ],
+ * }
+ * ```
+ */
+export type VitePluginInput =
+  | Plugin
+  | (() => Plugin | null)
+  | (() => Promise<Plugin | null>);
+
 export type Config = {
   stories: string;
   root: string;
@@ -146,7 +171,7 @@ export type Config = {
   defaultStory: string;
   babelPlugins: any[];
   babelPresets: any[];
-  vitePlugins: Plugin[];
+  vitePlugins: VitePluginInput[];
   define: { [key: string]: string };
   envPrefix: string | string[];
   css: {


### PR DESCRIPTION
Users can import their modules dynamically. Thus, we can only import it while loading configuration for Vite, and ignore it while importing in browsers.

Fixed #90 without introducing any breaking change 🎉 However, it needs more tests.

<img width="957" alt="截圖 2022-03-31 上午11 22 18" src="https://user-images.githubusercontent.com/28441561/160969943-96f1cc81-ab43-4648-b88b-6e2118251316.png">

<img width="541" alt="截圖 2022-03-31 上午11 22 53" src="https://user-images.githubusercontent.com/28441561/160970011-87973350-6d6b-43c6-a30c-6a38cad77ba4.png">

![SCR-20220331-fth](https://user-images.githubusercontent.com/28441561/160970133-d77836db-db51-4818-94f8-263047f791f4.jpeg)

