### PR TITLE
add option for babel parser

### DIFF
--- a/packages/example/CHANGELOG.md
+++ b/packages/example/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.21](https://github.com/tajo/ladle/compare/example@0.2.20...example@0.2.21) (2022-04-20)
+
+**Note:** Version bump only for package example
+
 ## [0.2.20](https://github.com/tajo/ladle/compare/example@0.2.19...example@0.2.20) (2022-04-19)
 
 **Note:** Version bump only for package example

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -10,7 +10,7 @@
     "test": "echo 'no test'"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/ladle/CHANGELOG.md
+++ b/packages/ladle/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.12.2](https://github.com/tajo/ladle/compare/@ladle/react@0.12.1...@ladle/react@0.12.2) (2022-04-20)
+
+### Bug Fixes
+
+- misspelled docs link ([#107](https://github.com/tajo/ladle/issues/107)) ([5365604](https://github.com/tajo/ladle/commit/5365604f7d9d2c4f9a0166af2240713ab974f80a))
+
 ## [0.12.1](https://github.com/tajo/ladle/compare/@ladle/react@0.12.0...@ladle/react@0.12.1) (2022-04-19)
 
 ### Bug Fixes

--- a/packages/ladle/lib/cli/vite-base.js
+++ b/packages/ladle/lib/cli/vite-base.js
@@ -108,6 +108,7 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
       //@ts-ignore
       react({
         babel: {
+          parserOpts: ladleConfig.babelParserOpts,
           presets: ladleConfig.babelPresets,
           plugins: ladleConfig.babelPlugins,
           compact: true,

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -17,6 +17,7 @@ export default {
   publicDir,
   enableFlow: false, // enable support for flow types
   defaultStory: "", // default story id to load, alphabetical by default
+  babelParserOpts: {},
   babelPresets: [],
   babelPlugins: [],
   vitePlugins: [],

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ladle/react",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "repository": "git@github.com:tajo/ladle.git",
   "author": "Vojtech Miksu <vojtech@miksu.cz>",
   "license": "MIT",

--- a/tests/addons/CHANGELOG.md
+++ b/tests/addons/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.21](https://github.com/tajo/ladle/compare/test-addons@0.1.20...test-addons@0.1.21) (2022-04-20)
+
+**Note:** Version bump only for package test-addons
+
 ## [0.1.20](https://github.com/tajo/ladle/compare/test-addons@0.1.19...test-addons@0.1.20) (2022-04-19)
 
 **Note:** Version bump only for package test-addons

--- a/tests/addons/package.json
+++ b/tests/addons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-addons",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "yarn test-dev && yarn test-prod"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "http-server": "^14.1.0",
     "react": "^18.0.0",

--- a/tests/commonjs/CHANGELOG.md
+++ b/tests/commonjs/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.21](https://github.com/tajo/ladle/compare/test-commonjs@0.2.20...test-commonjs@0.2.21) (2022-04-20)
+
+**Note:** Version bump only for package test-commonjs
+
 ## [0.2.20](https://github.com/tajo/ladle/compare/test-commonjs@0.2.19...test-commonjs@0.2.20) (2022-04-19)
 
 **Note:** Version bump only for package test-commonjs

--- a/tests/commonjs/package.json
+++ b/tests/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-commonjs",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "yarn test-prod && yarn test-dev"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "http-server": "^14.1.0",
     "react": "^18.0.0",

--- a/tests/css/CHANGELOG.md
+++ b/tests/css/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.12](https://github.com/tajo/ladle/compare/test-css@0.0.11...test-css@0.0.12) (2022-04-20)
+
+**Note:** Version bump only for package test-css
+
 ## [0.0.11](https://github.com/tajo/ladle/compare/test-css@0.0.10...test-css@0.0.11) (2022-04-19)
 
 **Note:** Version bump only for package test-css

--- a/tests/css/package.json
+++ b/tests/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-css",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "yarn test-dev && yarn test-prod"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "autoprefixer": "^10.4.4",
     "http-server": "^14.1.0",

--- a/tests/decorators/CHANGELOG.md
+++ b/tests/decorators/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.21](https://github.com/tajo/ladle/compare/test-decorators@0.2.20...test-decorators@0.2.21) (2022-04-20)
+
+**Note:** Version bump only for package test-decorators
+
 ## [0.2.20](https://github.com/tajo/ladle/compare/test-decorators@0.2.19...test-decorators@0.2.20) (2022-04-19)
 
 **Note:** Version bump only for package test-decorators

--- a/tests/decorators/package.json
+++ b/tests/decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-decorators",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "yarn test-dev && yarn test-prod"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "http-server": "^14.1.0",
     "react": "^18.0.0",

--- a/tests/flow/CHANGELOG.md
+++ b/tests/flow/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/tajo/ladle/compare/test-flow@0.2.19...test-flow@0.2.20) (2022-04-20)
+
+**Note:** Version bump only for package test-flow
+
 ## [0.2.19](https://github.com/tajo/ladle/compare/test-flow@0.2.18...test-flow@0.2.19) (2022-04-19)
 
 **Note:** Version bump only for package test-flow

--- a/tests/flow/package.json
+++ b/tests/flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-flow",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "yarn test-dev && yarn test-prod"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "http-server": "^14.1.0",
     "react": "^18.0.0",

--- a/tests/programmatic/CHANGELOG.md
+++ b/tests/programmatic/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.21](https://github.com/tajo/ladle/compare/test-programmatic@0.2.20...test-programmatic@0.2.21) (2022-04-20)
+
+**Note:** Version bump only for package test-programmatic
+
 ## [0.2.20](https://github.com/tajo/ladle/compare/test-programmatic@0.2.19...test-programmatic@0.2.20) (2022-04-19)
 
 **Note:** Version bump only for package test-programmatic

--- a/tests/programmatic/package.json
+++ b/tests/programmatic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-programmatic",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "license": "MIT",
   "private": true,
   "type": "module",
@@ -14,7 +14,7 @@
     "test": "yarn test-dev && yarn test-prod"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "http-server": "^14.1.0",
     "react": "^18.0.0",

--- a/tests/provider/CHANGELOG.md
+++ b/tests/provider/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.21](https://github.com/tajo/ladle/compare/test-provider@0.2.20...test-provider@0.2.21) (2022-04-20)
+
+**Note:** Version bump only for package test-provider
+
 ## [0.2.20](https://github.com/tajo/ladle/compare/test-provider@0.2.19...test-provider@0.2.20) (2022-04-19)
 
 **Note:** Version bump only for package test-provider

--- a/tests/provider/package.json
+++ b/tests/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-provider",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "test": "yarn test-dev && yarn test-prod"
   },
   "dependencies": {
-    "@ladle/react": "^0.12.1",
+    "@ladle/react": "^0.12.2",
     "@playwright/test": "1.19.2",
     "http-server": "^14.1.0",
     "react": "^18.0.0",


### PR DESCRIPTION
Add support to edit options for babel parsers: https://babeljs.io/docs/en/babel-parser#options
This is useful to change parser options for TypeScript, adding decorator legacy and so on.