### PR TITLE
Add support for custom host config

### DIFF
--- a/packages/ladle/lib/cli/cli.js
+++ b/packages/ladle/lib/cli/cli.js
@@ -14,6 +14,7 @@ program
   .command("serve")
   .description("start developing")
   .option("--stories [string]", "glob to find stories")
+  .option("--host [string]", "custom host to bind vite server to")
   .option("--port [number]", "port to serve the application", strToInt)
   .option("--theme [string]", "theme light, dark or auto")
   .option(

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -27,6 +27,7 @@ const bundler = async (config, configFolder) => {
       mode: "development",
       define: config.serve.define,
       server: {
+        host: config.serve.host,
         port: config.serve.port,
         open: config.serve.open,
         fs: {
@@ -57,7 +58,7 @@ const bundler = async (config, configFolder) => {
 
       if (config.serve.open !== "none") {
         await open(
-          `http://localhost:${port}`,
+          `http://${config.serve.host || 'localhost'}:${port}`,
           ["chrome", "firefox", "edge", "safari"].includes(config.serve.open)
             ? { app: { name: config.serve.open } }
             : {},


### PR DESCRIPTION
Vite config allows for passing a custom `server.host` configuration which enables the user to bind the server to a specific hostname to be able to access the server on a local network, for example.

The proposed change adds `--host` option to CLI `serve` command and passes the value to the vite config `server.host` property.