### PR TITLE
feat: onViteConfig

### DIFF
--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -35,7 +35,9 @@ const bundler = async (config, configFolder) => {
         middlewareMode: "html",
       },
     });
-    const vite = await createServer(viteConfig);
+    const vite = await createServer(
+      await config.onViteConfig({ config: viteConfig }),
+    );
     app.head("*", async (_, res) => res.sendStatus(200));
     app.get("/meta.json", async (_, res) => {
       const entryData = await getEntryData(await globby([config.stories]));

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -74,4 +74,16 @@ export default {
     baseUrl: "/",
     define: {}, // https://vitejs.dev/config/#define for prod build
   },
+  // any other custom vite configurations not available above, supports promise return also
+  /**
+   * @typedef { import("../shared/types").OnViteConfigOptions } OnViteConfigOptions
+   * @typedef { import("../shared/types").UserConfigVite } UserConfigVite
+   */
+  /**
+   * @param { OnViteConfigOptions }  options - arguments for callback
+   * @returns { UserConfigVite } A valid vite config
+   */
+  onViteConfig(options) {
+    return options.config;
+  },
 };

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -1,4 +1,10 @@
-import type { CSSModulesOptions, Plugin } from "vite";
+import type {
+  CSSModulesOptions,
+  Plugin,
+  UserConfig as UserConfigVite,
+} from "vite";
+
+export { UserConfigVite };
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
@@ -155,6 +161,10 @@ export type VitePluginInput =
   | (() => Plugin | null)
   | (() => Promise<Plugin | null>);
 
+export type OnViteConfigOptions = {
+  config: UserConfigVite;
+};
+
 export type Config = {
   stories: string;
   root: string;
@@ -215,6 +225,9 @@ export type Config = {
     baseUrl: string;
     define: { [key: string]: string };
   };
+  onViteConfig(
+    options: OnViteConfigOptions,
+  ): UserConfigVite | Promise<UserConfigVite>;
 };
 
 export type UserConfig = RecursivePartial<Config>;

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -118,6 +118,11 @@ export default {
     baseUrl: "/",
     define: {}, // https://vitejs.dev/config/#define for prod build
   },
+  // any other custom vite configurations not available above, supports promise return also
+  onViteConfig({ config }) {
+    config.mode = 'test'
+    return config;
+  },
 };
 ```
 


### PR DESCRIPTION
Vite has a lot of configuration options not covered by ladle, this callback will enable any custom modifications on the vite config before creating the dev server.

In this case I want to add the vite.server.proxy object to proxy some endpoints for the story components to use.
This will also render all feature requests to expose any uncovered vite config in the future needless.