### PR TITLE
feat: allow configuration Vite config.resolve object

### DIFF
--- a/.changeset/twelve-turtles-fold.md
+++ b/.changeset/twelve-turtles-fold.md
@@ -1,0 +1,6 @@
+---
+"@ladle/react": patch
+"website": patch
+---
+
+feat: allow configuration of the whole Vite config.resolve object

--- a/packages/ladle/lib/cli/vite-base.js
+++ b/packages/ladle/lib/cli/vite-base.js
@@ -67,6 +67,7 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
     envDir: process.cwd(),
     envPrefix: ladleConfig.envPrefix,
     resolve: {
+      ...ladleConfig.resolve,
       alias: {
         ...reactAlias,
         ...ladleConfig.resolve.alias,

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -26,9 +26,8 @@ export default {
   css: {
     modules: {},
   },
-  resolve: {
-    alias: {}, // https://vitejs.dev/config/#resolve-alias
-  },
+  // see resolve section at https://vitejs.dev/config
+  resolve: {},
   optimizeDeps: {
     include: [], // https://vitejs.dev/config/#optimizedeps-include
   },

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -170,9 +170,7 @@ export type Config = {
   css: {
     modules: CSSModulesOptions;
   };
-  resolve: {
-    alias: { [key: string]: string };
-  };
+  resolve: { [key: string]: any };
   optimizeDeps: {
     include: string[];
   };

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -72,9 +72,8 @@ export default {
     modules: {}, // https://vitejs.dev/config/#css-modules
   },
   define: {}, // https://vitejs.dev/config/#define
-  resolve: {
-    alias: {}, // https://vitejs.dev/config/#resolve-alias
-  },
+  // see resolve section at https://vitejs.dev/config
+  resolve: {},
   optimizeDeps: {
     include: [], // https://vitejs.dev/config/#optimizedeps-include
   },


### PR DESCRIPTION
Why:
Setup react-native-web requires vite resolve.extensions to be set to for example:
```javascript
    resolve: {
      extensions:['.web.tsx', '.web.ts', '.mjs', '.js', '.ts', '.jsx', '.tsx', '.json']
    },
```
This is just another case of limited config options for vite.

https://necolas.github.io/react-native-web/docs/multi-platform
The file for react web components will simply have highest priority for `.web.ts?x` extension.