### PR TITLE
Force page reload when stories are defined through .bind({})

### DIFF
--- a/.changeset/green-emus-prove.md
+++ b/.changeset/green-emus-prove.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Force page reload for stories that are defined through .bind({}) syntax (controls). It seems that react-refresh can't detect those when creating boundaries.

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": ["build/**"]
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
fixes https://github.com/tajo/ladle/issues/132 (somewhat)

This is a workaround. It seems that `react-refresh` is not able to detect components defined through `.bind({})` (used for story controls). An upstream fix might be possible there. 

This PR detects `.bind({})`, opts-out of the HMR for top-level stories and forces full page reload. It's not as good experience as react refresh but at least it preserves controls state since we persist it through the URL.

As a user, you can also avoid this by moving the component (template) code into a separate file. Or if you use controls for a single story, you don't need template/bind pattern at all.