### PR TITLE
Update(cli): allow disable `build.minify` option in prod build

### DIFF
--- a/packages/ladle/lib/cli/build.js
+++ b/packages/ladle/lib/cli/build.js
@@ -68,6 +68,10 @@ const build = async (params = {}) => {
     params.build && params.build.baseUrl
       ? params.build.baseUrl
       : config.build.baseUrl;
+  config.build.minify =
+    params.build && params.build.minify
+      ? params.build.minify
+      : config.build.minify;
   config.babelPlugins = params.babelPlugins
     ? params.babelPlugins
     : config.babelPlugins;

--- a/packages/ladle/lib/cli/vite-prod.js
+++ b/packages/ladle/lib/cli/vite-prod.js
@@ -19,6 +19,7 @@ const viteProd = async (config, configFolder) => {
         sourcemap: config.build.sourcemap,
         emptyOutDir: true,
         chunkSizeWarningLimit: 1024,
+        minify: config.build.minify,
       },
     });
     await build(viteConfig);

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -72,5 +72,6 @@ export default {
     sourcemap: false,
     baseUrl: "/",
     define: {}, // https://vitejs.dev/config/#define for prod build
+    minify: false,
   },
 };

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -212,6 +212,7 @@ export type Config = {
     sourcemap: boolean | "hidden" | "inline" | undefined;
     baseUrl: string;
     define: { [key: string]: string };
+    minify: boolean;
   };
 };
 


### PR DESCRIPTION
Fixes: #150 

## Motivation 🔥 

it is difficult to use React DevTools in static exported components catalogue due to components name minification, so I added the option to disable vite's `build.minify` option.

