### PR TITLE
Load vite.config.ts the same way as Vite

### DIFF
--- a/.changeset/giant-shirts-remain.md
+++ b/.changeset/giant-shirts-remain.md
@@ -1,0 +1,19 @@
+---
+"test-config-ts": major
+"@ladle/react": minor
+---
+
+Load vite.config.ts the same way as Vite
+
+## WHAT the breaking change is
+
+(Only for the package maintainers) a new E2E packages is added.
+
+## WHY the change was made
+
+Ladle was not able to handle `vite.config.ts` the way Vite does.
+For example, Ladle was not able to load `vite.config.ts` which imported other TS modules.
+
+## HOW a consumer should update their code
+
+(Only for the package maintainers) recognize a new e2e workspace with `pnpm install`.

--- a/e2e/config-ts/.ladle/config.mjs
+++ b/e2e/config-ts/.ladle/config.mjs
@@ -1,4 +1,3 @@
 export default {
   stories: "src/**/*.show.{js,jsx,ts,tsx}",
-  viteConfig: "ladle-vite.config.js",
 };

--- a/e2e/config-ts/.ladle/config.mjs
+++ b/e2e/config-ts/.ladle/config.mjs
@@ -1,0 +1,4 @@
+export default {
+  stories: "src/**/*.show.{js,jsx,ts,tsx}",
+  viteConfig: "ladle-vite.config.js",
+};

--- a/e2e/config-ts/CHANGELOG.md
+++ b/e2e/config-ts/CHANGELOG.md
@@ -1,0 +1,36 @@
+# test-provider
+
+## 0.2.30
+
+### Patch Changes
+
+- Updated dependencies [[`a53c25a`](https://github.com/tajo/ladle/commit/a53c25abc20d18068bc9a404dfb0bf6c47ca428e)]:
+  - @ladle/react@1.0.1
+
+## 0.2.29
+
+### Patch Changes
+
+- Updated dependencies [[`f9a4965`](https://github.com/tajo/ladle/commit/f9a4965e8a7940f9aa41df2c2c8418d37f9f0d35), [`05bee5d`](https://github.com/tajo/ladle/commit/05bee5d155703fdbd57e4984e21eae6e20a24184)]:
+  - @ladle/react@1.0.0
+
+## 0.2.28
+
+### Patch Changes
+
+- Updated dependencies [[`daa717d`](https://github.com/tajo/ladle/commit/daa717dd680cf55da5afbc53809109212555fc3c), [`8568de6`](https://github.com/tajo/ladle/commit/8568de64640823bb0e66797195288a3b4e81fdb6)]:
+  - @ladle/react@0.16.0
+
+## 0.2.27
+
+### Patch Changes
+
+- Updated dependencies [[`421a0c3`](https://github.com/tajo/ladle/commit/421a0c3ef1b97ec2db416c49cadcdd422398ec06)]:
+  - @ladle/react@0.15.2
+
+## 0.2.26
+
+### Patch Changes
+
+- Updated dependencies [[`2351356`](https://github.com/tajo/ladle/commit/235135613503255bf0e1bf0af5332b7b08d00f2b), [`f0a42ad`](https://github.com/tajo/ladle/commit/f0a42ad7123e30c8ab71d63d843bf0d9670b4931), [`515d069`](https://github.com/tajo/ladle/commit/515d0696665df786e45b5c76aed88239c68cdf24), [`c027c8c`](https://github.com/tajo/ladle/commit/c027c8c0a8a2442317b068787c039a580bf2c502), [`fa8db60`](https://github.com/tajo/ladle/commit/fa8db60ceba04e9d0fab519ad4b3b84e88ba412d), [`e2069f4`](https://github.com/tajo/ladle/commit/e2069f4b3d2b0b69a034c28e508a171ce011c45a), [`0a44aa2`](https://github.com/tajo/ladle/commit/0a44aa2a1b40f392db3163cddfdae7633771edec)]:
+  - @ladle/react@0.15.1

--- a/e2e/config-ts/ladle-vite.config.js
+++ b/e2e/config-ts/ladle-vite.config.js
@@ -1,5 +1,0 @@
-export default {
-  server: {
-    open: "none",
-  },
-};

--- a/e2e/config-ts/ladle-vite.config.js
+++ b/e2e/config-ts/ladle-vite.config.js
@@ -1,0 +1,5 @@
+export default {
+  server: {
+    open: "none",
+  },
+};

--- a/e2e/config-ts/package.json
+++ b/e2e/config-ts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "test-config-ts",
+  "version": "0.2.30",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "serve": "ladle serve --port=61107",
+    "serve-prod": "http-server build -c-1 -s -p 61107",
+    "build": "ladle build",
+    "lint": "echo 'no lint'",
+    "test-dev": "start-server-and-test serve 61107 'PW_EXPERIMENTAL_TS_ESM=1 npx playwright test'",
+    "test-prod": "start-server-and-test serve-prod 61107 'PW_EXPERIMENTAL_TS_ESM=1 npx playwright test'",
+    "test": "npm run test-dev && npm run test-prod"
+  },
+  "dependencies": {
+    "@ladle/react": "workspace:*",
+    "@playwright/test": "1.19.2",
+    "http-server": "^14.1.0",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
+    "start-server-and-test": "^1.14.0"
+  }
+}

--- a/e2e/config-ts/package.json
+++ b/e2e/config-ts/package.json
@@ -4,12 +4,12 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "serve": "ladle serve --port=61107",
-    "serve-prod": "http-server build -c-1 -s -p 61107",
+    "serve": "ladle serve --port=61108",
+    "serve-prod": "http-server build -c-1 -s -p 61108",
     "build": "ladle build",
     "lint": "echo 'no lint'",
-    "test-dev": "start-server-and-test serve 61107 'PW_EXPERIMENTAL_TS_ESM=1 npx playwright test'",
-    "test-prod": "start-server-and-test serve-prod 61107 'PW_EXPERIMENTAL_TS_ESM=1 npx playwright test'",
+    "test-dev": "start-server-and-test serve 61108 'PW_EXPERIMENTAL_TS_ESM=1 npx playwright test'",
+    "test-prod": "start-server-and-test serve-prod 61108 'PW_EXPERIMENTAL_TS_ESM=1 npx playwright test'",
     "test": "npm run test-dev && npm run test-prod"
   },
   "dependencies": {

--- a/e2e/config-ts/src/hello.show.tsx
+++ b/e2e/config-ts/src/hello.show.tsx
@@ -1,0 +1,3 @@
+export const World = () => {
+  return <h1>Hello World</h1>;
+};

--- a/e2e/config-ts/src/hello.show.tsx
+++ b/e2e/config-ts/src/hello.show.tsx
@@ -1,3 +1,26 @@
+declare const __filename_root: string;
+declare const __dirname_root: string;
+declare const __filename_myPlugin: string;
+declare const __dirname_myPlugin: string;
+
 export const World = () => {
-  return <h1>Hello World</h1>;
+  return (
+    <div>
+      <h1>Hello World</h1>
+
+      <dl>
+        <dt>filename root</dt>
+        <dd data-test="filename_root">{__filename_root}</dd>
+
+        <dt>dirname root</dt>
+        <dd data-test="dirname_root">{__dirname_root}</dd>
+
+        <dt>filename myPlugin</dt>
+        <dd data-test="filename_myPlugin">{__filename_myPlugin}</dd>
+
+        <dt>dirname myPlugin</dt>
+        <dd data-test="dirname_myPlugin">{__dirname_myPlugin}</dd>
+      </dl>
+    </div>
+  );
 };

--- a/e2e/config-ts/tests/hello.spec.ts
+++ b/e2e/config-ts/tests/hello.spec.ts
@@ -1,6 +1,24 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("default story is rendered", async ({ page }) => {
-  await page.goto("http://localhost:61107");
+  await page.goto("http://localhost:61108");
   await expect(page.locator("h1")).toHaveText("Hello World");
+});
+
+test("__filename and __dirname are replaced", async ({ page }) => {
+  await page.goto("http://localhost:61108");
+
+  await expect(page.locator("[data-test=filename_root]")).toHaveText(
+    /e2e\/config-ts\/vite\.config\.ts/,
+  );
+  await expect(page.locator("[data-test=dirname_root]")).toHaveText(
+    /e2e\/config-ts/,
+  );
+
+  await expect(page.locator("[data-test=filename_myPlugin]")).toHaveText(
+    /e2e\/config-ts\/vite-my-plugin\.ts/,
+  );
+  await expect(page.locator("[data-test=dirname_myPlugin]")).toHaveText(
+    /e2e\/config-ts/,
+  );
 });

--- a/e2e/config-ts/tests/hello.spec.ts
+++ b/e2e/config-ts/tests/hello.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "@playwright/test";
+
+test("default story is rendered", async ({ page }) => {
+  await page.goto("http://localhost:61107");
+  await expect(page.locator("h1")).toHaveText("Hello World");
+});

--- a/e2e/config-ts/vite-my-plugin.ts
+++ b/e2e/config-ts/vite-my-plugin.ts
@@ -1,0 +1,16 @@
+export default function myPlugin() {
+  return {
+    name: "vite-my-plugin",
+
+    config() {
+      return {
+        define: {
+          // @ts-ignore
+          __filename_myPlugin: JSON.stringify(__filename),
+          // @ts-ignore
+          __dirname_myPlugin: JSON.stringify(__dirname),
+        },
+      };
+    },
+  };
+}

--- a/e2e/config-ts/vite.config.ts
+++ b/e2e/config-ts/vite.config.ts
@@ -1,0 +1,15 @@
+import myPlugin from "./vite-my-plugin";
+
+export default {
+  server: {
+    open: "none",
+  },
+
+  define: {
+    // @ts-ignore
+    __filename_root: JSON.stringify(__filename),
+    // @ts-ignore
+    __dirname_root: JSON.stringify(__dirname),
+  },
+  plugins: [myPlugin()],
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "e2e/addons",
     "e2e/commonjs",
     "e2e/config",
+    "e2e/config-ts",
     "e2e/css",
     "e2e/decorators",
     "e2e/flow",

--- a/packages/ladle/lib/cli/get-user-vite-config.js
+++ b/packages/ladle/lib/cli/get-user-vite-config.js
@@ -1,6 +1,6 @@
 import { isAbsolute, join } from "path";
+import { loadConfigFromFile } from "vite";
 import debug from "./debug.js";
-import loadUserViteConfig from "./load-user-vite-config.js";
 
 // vite.config.js paths are relative to the project root
 // but for ladle, the root is in a different package, so
@@ -40,26 +40,16 @@ const getCacheDir = (cacheDir) => {
  * @return {Promise<import('../shared/types').GetUserViteConfig>}
  */
 export default async (command, mode, viteConfig) => {
-  /**
-   * @type {import('vite').UserConfigExport}
-   */
-  //@ts-ignore
-  let rawUserViteConfig = await loadUserViteConfig(viteConfig);
-  if (!rawUserViteConfig) {
+  const userViteConfig = await loadConfigFromFile(
+    { command, mode },
+    viteConfig,
+  ).then((loaded) => loaded?.config);
+  if (!userViteConfig) {
     return {
       userViteConfig: {},
       hasReactPlugin: false,
       hasTSConfigPathPlugin: false,
     };
-  }
-  /** @type {import('vite').UserConfig} */
-  let userViteConfig;
-  if (typeof rawUserViteConfig === "function") {
-    userViteConfig = await rawUserViteConfig({ command, mode });
-  } else {
-    userViteConfig = /** @type {import('vite').UserConfig} */ (
-      rawUserViteConfig
-    );
   }
 
   debug(`user vite config loaded:`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,22 @@ importers:
       react-dom: 18.1.0_react@18.1.0
       start-server-and-test: 1.14.0
 
+  e2e/config-ts:
+    specifiers:
+      "@ladle/react": workspace:*
+      "@playwright/test": 1.19.2
+      http-server: ^14.1.0
+      react: ^18.1.0
+      react-dom: ^18.1.0
+      start-server-and-test: ^1.14.0
+    dependencies:
+      "@ladle/react": link:../../packages/ladle
+      "@playwright/test": 1.19.2
+      http-server: 14.1.0
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      start-server-and-test: 1.14.0
+
   e2e/css:
     specifiers:
       "@ladle/react": workspace:*
@@ -4239,7 +4255,7 @@ packages:
     dependencies:
       "@types/istanbul-lib-coverage": 2.0.4
       "@types/istanbul-reports": 3.0.1
-      "@types/node": 17.0.31
+      "@types/node": 17.0.41
       "@types/yargs": 16.0.4
       chalk: 4.1.2
 
@@ -5350,7 +5366,7 @@ packages:
       }
     requiresBuild: true
     dependencies:
-      "@types/node": 17.0.31
+      "@types/node": 17.0.41
     optional: true
 
   /@typescript-eslint/eslint-plugin/5.22.0_lnjlwhtxjffjmj5o7dnwvwyqxq:
@@ -6566,7 +6582,10 @@ packages:
     dev: true
 
   /buffer-crc32/0.2.13:
-    resolution: { integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI= }
+    resolution:
+      {
+        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
+      }
 
   /buffer-from/1.1.2:
     resolution:
@@ -9183,7 +9202,10 @@ packages:
     dev: false
 
   /fd-slicer/1.1.0:
-    resolution: { integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4= }
+    resolution:
+      {
+        integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==,
+      }
     dependencies:
       pend: 1.2.0
 
@@ -10504,7 +10526,10 @@ packages:
     dev: false
 
   /ip/1.1.5:
-    resolution: { integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo= }
+    resolution:
+      {
+        integrity: sha512-rBtCAQAJm8A110nbwn6YdveUnuZH3WrC36IwkRXxDnq53JvXA2NVQvB7IHyKomxK1MJ4VDNw3UtFDdXQ+AvLYA==,
+      }
 
   /ipaddr.js/1.9.1:
     resolution:
@@ -11689,7 +11714,10 @@ packages:
     dev: true
 
   /json5/0.5.1:
-    resolution: { integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE= }
+    resolution:
+      {
+        integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==,
+      }
     hasBin: true
 
   /json5/1.0.1:
@@ -13068,7 +13096,10 @@ packages:
     dev: false
 
   /pend/1.2.0:
-    resolution: { integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA= }
+    resolution:
+      {
+        integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==,
+      }
 
   /picocolors/1.0.0:
     resolution:
@@ -14877,7 +14908,10 @@ packages:
     dev: false
 
   /retry/0.12.0:
-    resolution: { integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs= }
+    resolution:
+      {
+        integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==,
+      }
     engines: { node: ">= 4" }
 
   /retry/0.13.1:
@@ -15468,7 +15502,10 @@ packages:
     dev: false
 
   /source-map/0.5.7:
-    resolution: { integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w= }
+    resolution:
+      {
+        integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==,
+      }
     engines: { node: ">=0.10.0" }
 
   /source-map/0.6.1:
@@ -17646,7 +17683,10 @@ packages:
     dev: true
 
   /yauzl/2.10.0:
-    resolution: { integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk= }
+    resolution:
+      {
+        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
+      }
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - "e2e/addons"
   - "e2e/commonjs"
   - "e2e/config"
+  - "e2e/config-ts"
   - "e2e/css"
   - "e2e/decorators"
   - "e2e/flow"


### PR DESCRIPTION
Hi maintainers 👋 
I would like to contribute to the great project!

I tried to follow [the Contributing Guide](https://github.com/tajo/ladle/blob/42e3cf9a0d6273a9850850f5e6836871316ef63d/CONTRIBUTING.md).

## WHAT the breaking change is

(Only for the package maintainers) a new E2E packages is added.

## WHY the change was made

Ladle was not able to handle `vite.config.ts` the way Vite does.
For example, Ladle was not able to load `vite.config.ts` which imported other TS modules.

## HOW a consumer should update their code

(Only for the package maintainers) recognize a new e2e workspace with `pnpm install`.