### PR TITLE
Features/@ladle/react engine version

### DIFF
--- a/.changeset/nervous-ways-hunt.md
+++ b/.changeset/nervous-ways-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Add engine settings and node restriction for @ladle/react so that install fails for users when node < 16.x

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "pretty-quick": "^3.1.3",
     "turbo": "^1.2.5",
     "typescript": "^4.6.4"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   }
 }

--- a/packages/ladle/.npmrc
+++ b/packages/ladle/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
Problem:
Users install @ladle/react may receive errors when their Node version is less than 16.x

Solution:
Update package/ladle/package.json to add an `engines` section, and add a .npmrc at package/ladle to enforce the engine restriction.