### PR TITLE
feat(devcontainer): add devcontainer config files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,63 @@
+ARG VARIANT=v1.23.0-focal
+FROM mcr.microsoft.com/playwright:${VARIANT}
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The playwright image comes with a base non-root 'pwuser' user which this Dockerfile
+# gives sudo access. However, for Linux, this user's GID/UID must match your local
+# user UID/GID to avoid permission issues with bind mounts. Update USER_UID / USER_GID
+# if yours is not 1000. See https://aka.ms/vscode-remote/containers/non-root-user.
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Update and install packages, configure shells, configure npm, etc
+RUN apt-get update \
+    #
+    # Ensure base apt utilities are present
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git and needed tools (mostly for playwright testing) are installed
+    && apt-get -y install git iproute2 procps curl apt-transport-https lsb-release libgtkextra-dev libgconf2-dev libnss3 libasound2 libxtst-dev sudo \
+    #
+    # Install and setup ZSH for root and non-root users
+    && apt-get -y install --no-install-recommends zsh \
+    && chsh -s $(which zsh) root \
+    && chsh -s $(which zsh) pwuser \
+    && curl -Lo /home/pwuser/oh-my-zsh-install.sh --create-dirs https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh \
+    && chmod a+rx /home/pwuser/oh-my-zsh-install.sh \
+    && su -c "RUNZSH=no CHSH=no /home/pwuser/oh-my-zsh-install.sh --unattended" - root \
+    && su -c "RUNZSH=no CHSH=no /home/pwuser/oh-my-zsh-install.sh --unattended" - pwuser \
+    #
+    # Ensure npm saves exact versions
+    && su -c "npm config set save-exact true" - root \
+    && su -c "npm config set save-exact true" - pwuser \
+    #
+    # Configure global npm installs to use an unprivileged directory
+    && su -c "mkdir -p /home/pwuser/.npm-globals" - pwuser \
+    && su -c "npm config set prefix /home/pwuser/.npm-globals" - pwuser \
+    #
+    # Update a non-root user to match UID/GID - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && if [ "$USER_GID" != "1000" ]; then groupmod pwuser --gid $USER_GID; fi \
+    && if [ "$USER_UID" != "1000" ]; then usermod --uid $USER_UID pwuser; fi \
+    # Add add sudo support for non-root user
+    && echo pwuser ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/pwuser \
+    && chmod 0440 /etc/sudoers.d/pwuser \
+    #
+    # Clean up caches to reduce image size
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /home/pwuser/oh-my-zsh-install.sh
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=
+
+# Use unprivileged user
+USER pwuser
+
+# Ensure unprivileged user's global node_modules are first on the path
+ENV PATH=/home/pwuser/.npm-globals/bin:${PATH}
+
+# Install project package managers
+RUN npm install --location=global npm@8 pnpm@7

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Ladle",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "v1.23.0-focal"
+    }
+  },
+  "runArgs": [
+    // https://playwright.dev/docs/docker#usage
+    "--security-opt",
+    "seccomp=${localWorkspaceFolder}/.devcontainer/seccomp_profile.json"
+  ],
+  "remoteUser": "pwuser",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.devcontainer/seccomp_profile.json
+++ b/.devcontainer/seccomp_profile.json
@@ -1,0 +1,697 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": ["SCMP_ARCH_X86", "SCMP_ARCH_X32"]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": ["SCMP_ARCH_ARM"]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": ["SCMP_ARCH_MIPS", "SCMP_ARCH_MIPS64N32"]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": ["SCMP_ARCH_MIPS", "SCMP_ARCH_MIPS64"]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": ["SCMP_ARCH_MIPSEL", "SCMP_ARCH_MIPSEL64N32"]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": ["SCMP_ARCH_MIPSEL", "SCMP_ARCH_MIPSEL64"]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": ["SCMP_ARCH_S390"]
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_adjtime",
+        "clock_adjtime64",
+        "clock_getres",
+        "clock_getres_time64",
+        "clock_gettime",
+        "clock_gettime64",
+        "clock_nanosleep",
+        "clock_nanosleep_time64",
+        "close",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsetxattr",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futex_time64",
+        "futimesat",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "get_robust_list",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "get_thread_area",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "ioctl",
+        "io_destroy",
+        "io_getevents",
+        "io_pgetevents",
+        "io_pgetevents_time64",
+        "ioprio_get",
+        "ioprio_set",
+        "io_setup",
+        "io_submit",
+        "io_uring_enter",
+        "io_uring_register",
+        "io_uring_setup",
+        "ipc",
+        "kill",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listxattr",
+        "llistxattr",
+        "_llseek",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "membarrier",
+        "memfd_create",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedreceive_time64",
+        "mq_timedsend",
+        "mq_timedsend_time64",
+        "mq_unlink",
+        "mremap",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "nanosleep",
+        "newfstatat",
+        "_newselect",
+        "open",
+        "openat",
+        "pause",
+        "pipe",
+        "pipe2",
+        "poll",
+        "ppoll",
+        "ppoll_time64",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "pselect6",
+        "pselect6_time64",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmmsg_time64",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "rmdir",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_sigtimedwait_time64",
+        "rt_tgsigqueueinfo",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_rr_get_interval_time64",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "semtimedop_time64",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "set_robust_list",
+        "setsid",
+        "setsockopt",
+        "set_thread_area",
+        "set_tid_address",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd",
+        "signalfd4",
+        "sigprocmask",
+        "sigreturn",
+        "socket",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_gettime64",
+        "timer_settime",
+        "timer_settime64",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_gettime64",
+        "timerfd_settime",
+        "timerfd_settime64",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "utime",
+        "utimensat",
+        "utimensat_time64",
+        "utimes",
+        "vfork",
+        "vmsplice",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": ["ptrace"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": null,
+      "comment": "",
+      "includes": {
+        "minKernel": "4.8"
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 0,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 8,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131072,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131080,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": ["personality"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 4294967295,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": ["sync_file_range2"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": ["ppc64le"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "sync_file_range2",
+        "breakpoint",
+        "cacheflush",
+        "set_tls"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": ["arm", "arm64"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["arch_prctl"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": ["amd64", "x32"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["modify_ldt"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": ["amd64", "x32", "x86"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": ["s390", "s390x"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["open_by_handle_at"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_DAC_READ_SEARCH"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "bpf",
+        "clone",
+        "fanotify_init",
+        "lookup_dcookie",
+        "mount",
+        "name_to_handle_at",
+        "perf_event_open",
+        "quotactl",
+        "setdomainname",
+        "sethostname",
+        "setns",
+        "syslog",
+        "umount",
+        "umount2",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_ADMIN"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["clone"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 2114060288,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": ["CAP_SYS_ADMIN"],
+        "arches": ["s390", "s390x"]
+      }
+    },
+    {
+      "names": ["clone"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 1,
+          "value": 2114060288,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "s390 parameter ordering for clone is different",
+      "includes": {
+        "arches": ["s390", "s390x"]
+      },
+      "excludes": {
+        "caps": ["CAP_SYS_ADMIN"]
+      }
+    },
+    {
+      "names": ["reboot"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_BOOT"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["chroot"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_CHROOT"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["delete_module", "init_module", "finit_module"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_MODULE"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["acct"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_PACCT"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["kcmp", "process_vm_readv", "process_vm_writev", "ptrace"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_PTRACE"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["iopl", "ioperm"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_RAWIO"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["settimeofday", "stime", "clock_settime"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_TIME"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["vhangup"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_TTY_CONFIG"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["get_mempolicy", "mbind", "set_mempolicy"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYS_NICE"]
+      },
+      "excludes": {}
+    },
+    {
+      "names": ["syslog"],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": ["CAP_SYSLOG"]
+      },
+      "excludes": {}
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,4 @@ build
 yarn-error.log
 cjs
 .turbo
-
-
-
-
+.pnpm-store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,14 @@ Install the depedencies after forking and cloning the repository
 pnpm install
 ```
 
+Install `playwright` dependencies used in testing
+
+```sh
+pnpm exec playwright install
+```
+
+> **NOTE:** this project has a [VS Code Devcontainer](https://code.visualstudio.com/docs/remote/containers) configuration which enables development inside of a docker container, as well as on [GitHub Codespaces](https://code.visualstudio.com/docs/remote/codespaces). This is a great option if you want to contribute to the project, but don't necessarily want to install this project's toolset and dependencies globally on your computer.
+
 ## Developing
 
 The main `@ladle/react` package can be found in `packages/ladle`. You can quickly test and debug your changes in `@ladle/react` by running `packages/example` (it's a toy project so feel free to add more stories there):


### PR DESCRIPTION
Provide the ability to work on this project inside of a Docker container and/or on GitHub Codespaces through the creation of `devcontainer` and `Docker` configuration files.

This helps contributors to all share the same development environment, notably, ensuring that everyone uses the same versions of the various tools required for development of Ladle. Further, it makes it possible to work on the project without the need to install this project's tools and dependencies globally on your computer.

The configurations build upon the official `Playwright` Docker images (and security profiles) to ensure contributors have everything they need to run development, testing, linting, and building processes.