### PR TITLE
Fix `resolve.alias` compat issue

### DIFF
--- a/.changeset/funny-cats-drive.md
+++ b/.changeset/funny-cats-drive.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Fix compatibility issue with resolve.alias vite config to fix issue tajo/ladle#187.

--- a/e2e/config/ladle-vite.config.js
+++ b/e2e/config/ladle-vite.config.js
@@ -2,4 +2,8 @@ export default {
   server: {
     open: "none",
   },
+  resolve: {
+    // See #184 - this tests the package for the resolve.alias RegExp format.
+    alias: [{ find: /any-cool-regex/, replacement: "any-string" }],
+  },
 };


### PR DESCRIPTION
Automatically detect the user config format for `resolve.alias` before configuring ladle for react v17.

Fixes #184