### PR TITLE
Improve startup performance, related to the virtual story module

### DIFF
--- a/.changeset/old-pumas-rush.md
+++ b/.changeset/old-pumas-rush.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Improve the performance of virtual stories modules. fs.promises.readFile much slower than fs.promises.readSync and it blocking CPU doesn't matter in our use case anyway. Also don't run the story watcher on the startup.

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -70,6 +70,7 @@ const bundler = async (config, configFolder) => {
     // trigger full reload when new stories are added or removed
     const watcher = chokidar.watch(config.stories, {
       persistent: true,
+      ignoreInitial: true,
     });
     let checkSum = "";
     const getChecksum = async () => {

--- a/packages/ladle/lib/cli/vite-plugin/parse/get-entry-data.js
+++ b/packages/ladle/lib/cli/vite-plugin/parse/get-entry-data.js
@@ -29,10 +29,9 @@ export const getEntryData = async (entries) => {
  * @param {string} entry
  */
 export const getSingleEntry = async (entry) => {
-  const code = await fs.promises.readFile(
-    path.join(process.cwd(), entry),
-    "utf8",
-  );
+  // fs.promises.readFile is much slower and we don't mind hogging
+  // the whole CPU core since this is blocking everything else
+  const code = fs.readFileSync(path.join(process.cwd(), entry), "utf8");
   /** @type {import('../../../shared/types').ParsedStoriesResult} */
   const result = {
     entry,


### PR DESCRIPTION
Improve the performance of virtual stories modules. `fs.promises.readFile` is much slower than `fs.promises.readSync` and blocking CPU doesn't matter in our use case anyway. Also don't run the story watcher on the startup.