### PR TITLE
Fix: React is not defined on `compose-enhancers.tsx`

### DIFF
--- a/packages/ladle/lib/app/src/compose-enhancers.tsx
+++ b/packages/ladle/lib/app/src/compose-enhancers.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import ArgsProvider from "./args-provider";
 
 export default function composeEnhancers(module: any, storyName: string) {

--- a/packages/ladle/lib/app/src/compose-enhancers.tsx
+++ b/packages/ladle/lib/app/src/compose-enhancers.tsx
@@ -1,4 +1,5 @@
-import * as React from "react";
+// @ts-nocheck
+import React from "react";
 import ArgsProvider from "./args-provider";
 
 export default function composeEnhancers(module: any, storyName: string) {


### PR DESCRIPTION
Hi, Ladle team,
I recently tried this tool as an alternative to Storybook. 
When I started the server, It didn't show any content on the screen, then I checked the console log info 
and found this error message:

![image](https://user-images.githubusercontent.com/30401991/182353833-e28339b2-07da-408d-b7c9-f12b1fd33d3a.png)

After that, I tried to change the code on that file and then tested it locally, the error has disappeared expectly and I can see this tool works well now. 
I think my change is pretty straightforward, hope you can approve. 
Thanks
