### PR TITLE
fix(build): import performance from perf_hooks in node context

### DIFF
--- a/packages/ladle/lib/cli/build.js
+++ b/packages/ladle/lib/cli/build.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import path from "path";
+import { performance } from "perf_hooks";
 import { promises as fs } from "fs";
 import { globby } from "globby";
 import viteProd from "./vite-prod.js";


### PR DESCRIPTION
```
$ /Users/starr/workspace/baseui/node_modules/.bin/ladle build --outDir build-ladle
(node:3427) UnhandledPromiseRejectionWarning: ReferenceError: performance is not defined
    at build (file:///Users/starr/workspace/baseui/node_modules/@ladle/react/lib/cli/build.js:17:21)
    at Command.<anonymous> (file:///Users/starr/workspace/baseui/node_modules/@ladle/react/lib/cli/cli.js:39:27)
    at Command.listener [as _actionHandler] (/Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:482:17)
    at /Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1265:65
    at Command._chainOrCall (/Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1159:12)
    at Command._parseCommand (/Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1265:27)
    at /Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1063:27
    at Command._chainOrCall (/Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1159:12)
    at Command._dispatchSubcommand (/Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1059:23)
    at Command._parseCommand (/Users/starr/workspace/baseui/node_modules/@ladle/react/node_modules/commander/lib/command.js:1230:19)
```

`performance` is not a global in node, updating here to import from `perf_hooks` module