### PR TITLE
Fix(dev-server): prevent redirect loop in top page

### DIFF
--- a/.changeset/polite-gorillas-jump.md
+++ b/.changeset/polite-gorillas-jump.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+fix prevent dev-server from redirecting loop in top page

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -51,7 +51,7 @@ const bundler = async (config, configFolder) => {
     // When `middlewareMode` is true, vite's own base middleware won't redirect requests,
     // so we need to do that ourselves.
     const { base } = viteConfig;
-    if (base && base !== "/") {
+    if (base && base !== "/" && base !== "./") {
       app.get("/", (_, res) => res.redirect(base));
       app.get("/index.html", (_, res) => res.redirect(base));
     }


### PR DESCRIPTION
Fixes: #227 

if I set `base` option in `vitest.config.ts` as `"./"`, ladle dev server causes redirect loop with `base: ./` config. I fixed this issue by preventing redirect if `base` option in `vite.config.ts` is `"./"` same as `"/"`