### PR TITLE
fix(config-file-entry): support config entry stories in array of strings

### DIFF
--- a/.changeset/wise-cheetahs-suffer.md
+++ b/.changeset/wise-cheetahs-suffer.md
@@ -1,0 +1,15 @@
+---
+"test-config": minor
+"@ladle/react": minor
+---
+
+Fix config file to support entry files of array of strings
+
+The `.ladle/config.mjs` files now supports array of strings for stories
+
+```tsx
+// array of strings
+export default {
+  stories: ["src/**/control.stories.{js,jsx,ts,tsx}", "src/stories.custom.tsx"],
+};
+```

--- a/e2e/config/.ladle/config.mjs
+++ b/e2e/config/.ladle/config.mjs
@@ -1,4 +1,4 @@
 export default {
-  stories: "src/**/*.show.{js,jsx,ts,tsx}",
+  stories: ["src/**/*.show.{js,jsx,ts,tsx}", "src/specific-file.custom.tsx"],
   viteConfig: "ladle-vite.config.js",
 };

--- a/e2e/config/src/specific-file.custom.tsx
+++ b/e2e/config/src/specific-file.custom.tsx
@@ -1,0 +1,3 @@
+export const Custom = () => {
+  return <h1>Custom path</h1>;
+};

--- a/e2e/config/tests/custom-path.spec.ts
+++ b/e2e/config/tests/custom-path.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("custom path story is rendered", async ({ page }) => {
+  await page.goto("http://localhost:61107/?story=specific-file--custom");
+
+  await expect(page.locator("h1")).toHaveText("Custom path");
+});

--- a/packages/example/.ladle/config.mjs
+++ b/packages/example/.ladle/config.mjs
@@ -1,0 +1,16 @@
+/**
+ * This file is optional.
+ *
+ * To setup config for specific stories to be included
+ *
+ * stories: [
+ *    "src/a11y.stories.tsx",
+ *    "src/control.stories.tsx",
+ *    "src/controls.stories.tsx",
+ * ],
+ *
+ *  */
+
+export default {
+  stories: "src/**/*.stories.{js,jsx,ts,tsx}",
+};

--- a/packages/ladle/lib/cli/build.js
+++ b/packages/ladle/lib/cli/build.js
@@ -2,7 +2,7 @@
 
 import path from "path";
 import { promises as fs } from "fs";
-import { performance } from 'perf_hooks';
+import { performance } from "perf_hooks";
 import { globby } from "globby";
 import viteProd from "./vite-prod.js";
 import debug from "./debug.js";
@@ -19,7 +19,11 @@ const build = async (params = {}) => {
   debug("Starting build command");
   const { configFolder, config } = await applyCLIConfig(params);
   await viteProd(config, configFolder);
-  const entryData = await getEntryData(await globby([config.stories]));
+  const entryData = await getEntryData(
+    await globby(
+      Array.isArray(config.stories) ? config.stories : [config.stories],
+    ),
+  );
   const jsonContent = getMetaJsonString(entryData);
   await fs.writeFile(
     path.join(process.cwd(), config.outDir, "meta.json"),

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -44,7 +44,11 @@ const bundler = async (config, configFolder) => {
     const { moduleGraph, ws } = vite;
     app.head("*", async (_, res) => res.sendStatus(200));
     app.get("/meta.json", async (_, res) => {
-      const entryData = await getEntryData(await globby([config.stories]));
+      const entryData = await getEntryData(
+        await globby(
+          Array.isArray(config.stories) ? config.stories : [config.stories],
+        ),
+      );
       const jsonContent = getMetaJsonObject(entryData);
       res.json(jsonContent);
     });
@@ -88,7 +92,11 @@ const bundler = async (config, configFolder) => {
     let checkSum = "";
     const getChecksum = async () => {
       try {
-        const entryData = await getEntryData(await globby([config.stories]));
+        const entryData = await getEntryData(
+          await globby(
+            Array.isArray(config.stories) ? config.stories : [config.stories],
+          ),
+        );
         const jsonContent = getMetaJsonObject(entryData);
         // loc changes should not grant a full reload
         Object.keys(jsonContent.stories).forEach((storyId) => {

--- a/packages/ladle/lib/cli/vite-plugin/vite-plugin.js
+++ b/packages/ladle/lib/cli/vite-plugin/vite-plugin.js
@@ -90,7 +90,11 @@ function ladlePlugin(config, configFolder, mode) {
         debug(`transforming: ${id}`);
         try {
           debug("Initial generation of the list");
-          const entryData = await getEntryData(await globby([config.stories]));
+          const entryData = await getEntryData(
+            await globby(
+              Array.isArray(config.stories) ? config.stories : [config.stories],
+            ),
+          );
           detectDuplicateStoryNames(entryData);
           return getGeneratedList(entryData, configFolder, config);
         } catch (/** @type {any} */ e) {

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -23,9 +23,17 @@ Ladle does not require any configuration and some features can be controlled thr
 
 We use [globby](https://github.com/sindresorhus/globby), go there to learn about all possible search patterns. Ladle uses this parameter to find story files in your project.
 
+The entry of stories supports string or array of strings
+
 ```tsx
+// string
 export default {
   stories: "src/**/control.stories.{js,jsx,ts,tsx}",
+};
+
+// array of strings
+export default {
+  stories: ["src/**/control.stories.{js,jsx,ts,tsx}", "src/stories.custom.tsx"],
 };
 ```
 


### PR DESCRIPTION
Current issue:
The current version files to compile and thrown as error as describe in
https://github.com/tajo/ladle/issues/208

fix:
config file now supports array of strings as below

```
stories: [
    "src/a11y.stories.tsx",
    "src/control.stories.tsx",
    "src/controls.stories.tsx",
],
```


### TODO
- [x] e2e test for glob in the e2e config
- [x] add example description

resolves: #208 