### PR TITLE
Add scripts that modify the package.json before publishing

### DIFF
--- a/.changeset/tame-falcons-learn.md
+++ b/.changeset/tame-falcons-learn.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Update `package.json`'s "types" and "exports" so that they point to the type definition file, but only when publishing to NPM.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publishing next version
-        run: cd packages/ladle && ./publish-next.js
+        run: cd packages/ladle && pnpm types && ./publish-next.js
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -27,7 +27,8 @@
     "cli": "node ./lib/cli/cli.js",
     "clean": "rimraf dist && rimraf .ladle && rimraf build && rimraf *.tsbuildinfo",
     "serve": "node ./lib/cli/cli.js serve",
-    "test": "cross-env IMPORT_ROOT=\"./\" vitest"
+    "test": "cross-env IMPORT_ROOT=\"./\" vitest",
+    "types": "tsc --project tsconfig.typesoutput.json"
   },
   "dependencies": {
     "@babel/code-frame": "^7.18.6",

--- a/packages/ladle/publish-next.js
+++ b/packages/ladle/publish-next.js
@@ -2,6 +2,10 @@
 
 import { execSync } from "child_process";
 import fs from "fs";
+import {
+  preparePackageJsonForPublish,
+  revertPackageJson,
+} from "./scripts/package-types-helpers.js";
 
 const shortHash = execSync("git rev-parse --short HEAD").toString().trim();
 const version = `0.0.0-next-${shortHash}`;
@@ -13,6 +17,7 @@ const oldVersion = pkgJson.version;
 const oldContextVersion = pkgJson.dependencies["@ladle/react-context"];
 pkgJson.version = version;
 pkgJson.dependencies["@ladle/react-context"] = oldContextVersion.split(":")[1];
+preparePackageJsonForPublish(pkgJson);
 fs.writeFileSync("./package.json", JSON.stringify(pkgJson, null, 2));
 
 try {
@@ -24,4 +29,5 @@ try {
 
 pkgJson.version = oldVersion;
 pkgJson.dependencies["@ladle/react-context"] = oldContextVersion;
+revertPackageJson(pkgJson);
 fs.writeFileSync("./package.json", JSON.stringify(pkgJson, null, 2));

--- a/packages/ladle/scripts/package-types-helpers.js
+++ b/packages/ladle/scripts/package-types-helpers.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+let oldTypes = null;
+let oldExports = null;
+
+export function preparePackageJsonForPublish(packageJson) {
+  oldTypes = packageJson.types;
+  packageJson.types = "./lib/app/exports.d.ts";
+
+  oldExports = JSON.parse(JSON.stringify(packageJson.exports));
+  packageJson.exports["."] = {
+    types: "./lib/app/exports.d.ts",
+    default: "./lib/app/exports.ts",
+  };
+
+  return packageJson;
+}
+
+export function revertPackageJson(packageJson) {
+  if (!oldTypes) {
+    console.warn(`'oldTypes' is not defined, so we are unable to revert it`);
+  }
+
+  if (!oldExports) {
+    console.warn(`'oldExports' is not defined, so we are unable to revert it`);
+  }
+
+  packageJson.types = oldTypes ?? packageJson.types;
+  oldTypes = null;
+
+  packageJson.exports = oldExports ?? packageJson.exports;
+  oldExports = null;
+
+  return packageJson;
+}

--- a/packages/ladle/scripts/revert-package-types.js
+++ b/packages/ladle/scripts/revert-package-types.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+
+const pkgJson = JSON.parse(
+  fs.readFileSync("./packages/ladle/backup-package.json"),
+);
+// write updates to package.json
+fs.writeFileSync(
+  "./packages/ladle/package.json",
+  JSON.stringify(pkgJson, null, 2),
+);
+// remove backup file
+fs.rmSync("./packages/ladle/backup-package.json");

--- a/packages/ladle/scripts/update-package-types.js
+++ b/packages/ladle/scripts/update-package-types.js
@@ -1,0 +1,16 @@
+import { preparePackageJsonForPublish } from "./package-types-helpers.js";
+import fs from "fs";
+
+const pkgJson = JSON.parse(fs.readFileSync("./packages/ladle/package.json"));
+// write out old package.json to a temp file that won't be published
+fs.writeFileSync(
+  "./packages/ladle/backup-package.json",
+  JSON.stringify(pkgJson, null, 2),
+);
+// update existing package.json
+preparePackageJsonForPublish(pkgJson);
+// write updates to package.json
+fs.writeFileSync(
+  "./packages/ladle/package.json",
+  JSON.stringify(pkgJson, null, 2),
+);

--- a/packages/ladle/tsconfig.typesoutput.json
+++ b/packages/ladle/tsconfig.typesoutput.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["lib/**/*", "src/**/*"]
+}

--- a/release.sh
+++ b/release.sh
@@ -7,5 +7,14 @@ echo "Running release"
 echo "Build @ladle/react"
 turbo run build --filter=@ladle/react
 
+echo "Update package.json"
+node ./packages/ladle/scripts/update-package-types.js
+
+echo "Generate Types":
+pnpm --filter @ladle/react types
+
 echo "Changeset publish"
 changeset publish
+
+echo "Revert package.json"
+node ./packages/ladle/scripts/revert-package-types.js


### PR DESCRIPTION
In order to get TS types working correctly for "Node16" and "NodeNext"

Closes #267 

For normal npm versions: 
1. Update `release.sh` to run `update-package-types.js`, which 
2. Makes a copy of package.json as `backup-package.json`, and then 
3. Writes the necessary changes out to `package.json`, and then
4. Generates the types with an npm script, and then
5. Reverts `package.json` from `backup-package.json` and deletes the backup-package.json.

😓 

For `next` npm versions, it was a bit easier since there was already a NodeJS script modifying package.json, so I just hooked into it to make those changes and made sure the npm script was executed.

---

I'm very open to changing any and all of this if you think there's something that needs to be changed. 👍 