### PR TITLE
Fix types for CJS projects using TypeScript NodeNext/Node16

### DIFF
--- a/.changeset/cyan-flies-yell.md
+++ b/.changeset/cyan-flies-yell.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Fix types for CJS projects using TypeScript's "NodeNext" or "Node16" resolution.

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -28,7 +28,7 @@
     "clean": "rimraf dist && rimraf .ladle && rimraf build && rimraf *.tsbuildinfo",
     "serve": "node ./lib/cli/cli.js serve",
     "test": "cross-env IMPORT_ROOT=\"./\" vitest",
-    "types": "tsc --project tsconfig.typesoutput.json"
+    "types": "tsc --project tsconfig.typesoutput.json && cp ./lib/app/exports.d.ts ./lib/app/exports.d.cts"
   },
   "dependencies": {
     "@babel/code-frame": "^7.18.6",

--- a/packages/ladle/scripts/package-types-helpers.js
+++ b/packages/ladle/scripts/package-types-helpers.js
@@ -9,7 +9,10 @@ export function preparePackageJsonForPublish(packageJson) {
 
   oldExports = JSON.parse(JSON.stringify(packageJson.exports));
   packageJson.exports["."] = {
-    types: "./lib/app/exports.d.ts",
+    types: {
+      import: "./lib/app/exports.d.ts",
+      require: "./lib/app/exports.d.cts",
+    },
     default: "./lib/app/exports.ts",
   };
 


### PR DESCRIPTION
Followup to #267 and #275 

Tested both ESM and CJS projects (by modifying the `example` package) and this works. 