### PR TITLE
Fix issue when publishing both next and current release

### DIFF
--- a/.changeset/dull-stingrays-explain.md
+++ b/.changeset/dull-stingrays-explain.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Fix issue in GitHub Actions when publishing both next and current release.

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error.log
 cjs
 .turbo
 .pnpm-store
+packages/ladle/typings-for-build

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -28,7 +28,7 @@
     "clean": "rimraf dist && rimraf .ladle && rimraf build && rimraf *.tsbuildinfo",
     "serve": "node ./lib/cli/cli.js serve",
     "test": "cross-env IMPORT_ROOT=\"./\" vitest",
-    "types": "tsc --project tsconfig.typesoutput.json && cp ./lib/app/exports.d.ts ./lib/app/exports.d.cts"
+    "types": "tsc --project tsconfig.typesoutput.json && cp ./typings-for-build/app/exports.d.ts ./typings-for-build/app/exports.d.cts"
   },
   "dependencies": {
     "@babel/code-frame": "^7.18.6",

--- a/packages/ladle/scripts/package-types-helpers.js
+++ b/packages/ladle/scripts/package-types-helpers.js
@@ -5,13 +5,13 @@ let oldExports = null;
 
 export function preparePackageJsonForPublish(packageJson) {
   oldTypes = packageJson.types;
-  packageJson.types = "./lib/app/exports.d.ts";
+  packageJson.types = "./typings-for-build/app/exports.d.ts";
 
   oldExports = JSON.parse(JSON.stringify(packageJson.exports));
   packageJson.exports["."] = {
     types: {
-      import: "./lib/app/exports.d.ts",
-      require: "./lib/app/exports.d.cts",
+      import: "./typings-for-build/app/exports.d.ts",
+      require: "./typings-for-build/app/exports.d.cts",
     },
     default: "./lib/app/exports.ts",
   };

--- a/packages/ladle/tsconfig.typesoutput.json
+++ b/packages/ladle/tsconfig.typesoutput.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noEmit": false,
     "declaration": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "declarationDir": "typings-for-build"
   },
-  "include": ["lib/**/*", "src/**/*"]
+  "include": ["lib/**/*", "src/**/*"],
+  "exclude": ["typings-for-build"]
 }


### PR DESCRIPTION
By emitting the types to their own folder, and then `exclude`-ing that folder in the `tsconfig.typesoutput.json`, it doesn't bother TS anymore that you have emitted twice.

Named the folder `typings-for-build` (and that folder should only show up when publishing, or testing the publish) but feel free to suggest changes for that name. 🙂 

Tested in the `example` repo for "NodeNext + CJS" and "NodeNext + ESM" and no issues. 