### PR TITLE
Solves consoles errors when using undefined options in argTypes, and displays 'undefined' as an option in control addon (select and radio)

### DIFF
--- a/.changeset/famous-ducks-cheer.md
+++ b/.changeset/famous-ducks-cheer.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"@ladle/react": patch
+---
+
+Patched bug relating to console errors and unexpected behavior when using undefined values in controls addon / argTypes

--- a/packages/example/src/controls.stories.tsx
+++ b/packages/example/src/controls.stories.tsx
@@ -36,12 +36,12 @@ Controls.args = {
 };
 Controls.argTypes = {
   variant: {
-    options: ["primary", "secondary"],
+    options: [undefined, "primary", "secondary"],
     control: { type: "radio" },
     defaultValue: "primary",
   },
   size: {
-    options: ["small", "medium", "big", "huuuuge"],
+    options: [undefined, "small", "medium", "big", "huuuuge"],
     control: { type: "select" },
   },
   onClick: {

--- a/packages/ladle/lib/app/src/addons/control.tsx
+++ b/packages/ladle/lib/app/src/addons/control.tsx
@@ -127,30 +127,35 @@ const Control = ({
       <tr>
         <td>{controlKey}</td>
         <td>
-          {(globalState.control[controlKey].options || []).map((option) => (
-            <span key={option}>
-              <input
-                id={`${controlKey}-${option}`}
-                type="radio"
-                name={controlKey}
-                value={option}
-                onChange={(e) => {
-                  dispatch({
-                    type: ActionType.UpdateControl,
-                    value: {
-                      ...globalState.control,
-                      [controlKey]: {
-                        ...globalState.control[controlKey],
-                        value: e.target.value,
+          {(globalState.control[controlKey].options || []).map((option) => {
+            const optionString = String(option);
+            return (
+              <span key={optionString + controlKey}>
+                <input
+                  id={`${controlKey}-${option}`}
+                  type="radio"
+                  name={controlKey}
+                  value={option}
+                  onChange={(e) => {
+                    dispatch({
+                      type: ActionType.UpdateControl,
+                      value: {
+                        ...globalState.control,
+                        [controlKey]: {
+                          ...globalState.control[controlKey],
+                          value: e.target.value || undefined,
+                        },
                       },
-                    },
-                  });
-                }}
-                checked={globalState.control[controlKey].value === option}
-              />
-              <label htmlFor={`${controlKey}-${option}`}>{option}</label>
-            </span>
-          ))}
+                    });
+                  }}
+                  checked={globalState.control[controlKey].value === option}
+                />
+                <label htmlFor={`${controlKey}-${option}`}>
+                  {optionString}
+                </label>
+              </span>
+            );
+          })}
         </td>
       </tr>
     );
@@ -178,11 +183,14 @@ const Control = ({
               });
             }}
           >
-            {(globalState.control[controlKey].options || []).map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
+            {(globalState.control[controlKey].options || []).map((option) => {
+              const optionString = String(option);
+              return (
+                <option key={optionString + controlKey} value={option}>
+                  {optionString}
+                </option>
+              );
+            })}
           </select>
         </td>
       </tr>

--- a/packages/ladle/lib/app/src/addons/control.tsx
+++ b/packages/ladle/lib/app/src/addons/control.tsx
@@ -127,35 +127,32 @@ const Control = ({
       <tr>
         <td>{controlKey}</td>
         <td>
-          {(globalState.control[controlKey].options || []).map((option) => {
-            const optionString = String(option);
-            return (
-              <span key={optionString + controlKey}>
-                <input
-                  id={`${controlKey}-${option}`}
-                  type="radio"
-                  name={controlKey}
-                  value={option}
-                  onChange={(e) => {
-                    dispatch({
-                      type: ActionType.UpdateControl,
-                      value: {
-                        ...globalState.control,
-                        [controlKey]: {
-                          ...globalState.control[controlKey],
-                          value: e.target.value || undefined,
-                        },
+          {(globalState.control[controlKey].options || []).map((option) => (
+            <span key={`${option}-${controlKey}`}>
+              <input
+                id={`${controlKey}-${option}`}
+                type="radio"
+                name={controlKey}
+                value={option}
+                onChange={(e) => {
+                  dispatch({
+                    type: ActionType.UpdateControl,
+                    value: {
+                      ...globalState.control,
+                      [controlKey]: {
+                        ...globalState.control[controlKey],
+                        value: e.target.value || undefined,
                       },
-                    });
-                  }}
-                  checked={globalState.control[controlKey].value === option}
-                />
-                <label htmlFor={`${controlKey}-${option}`}>
-                  {optionString}
-                </label>
-              </span>
-            );
-          })}
+                    },
+                  });
+                }}
+                checked={globalState.control[controlKey].value === option}
+              />
+              <label htmlFor={`${controlKey}-${option}`}>
+                {String(option)}
+              </label>
+            </span>
+          ))}
         </td>
       </tr>
     );
@@ -183,14 +180,11 @@ const Control = ({
               });
             }}
           >
-            {(globalState.control[controlKey].options || []).map((option) => {
-              const optionString = String(option);
-              return (
-                <option key={optionString + controlKey} value={option}>
-                  {optionString}
-                </option>
-              );
-            })}
+            {(globalState.control[controlKey].options || []).map((option) => (
+              <option key={`${option}-${controlKey}`} value={option}>
+                {String(option)}
+              </option>
+            ))}
           </select>
         </td>
       </tr>


### PR DESCRIPTION
Employs minimal changes to the existing code base. In addition I added undefined values to the example application for the radio and select options. 