### PR TITLE
Use undefined as default for controls

### DIFF
--- a/.changeset/witty-eagles-peel.md
+++ b/.changeset/witty-eagles-peel.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Use undefined as default for controls

--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -45,16 +45,62 @@ Controls.args = {
 };
 Controls.argTypes = {
   variant: {
-    options: ["primary", "secondary", true, false, undefined],
+    options: ["primary", "secondary", true, false],
     control: { type: "radio" },
     defaultValue: "primary",
   },
   size: {
-    options: ["small", "medium", "big", true, false, undefined],
+    options: ["small", "medium", "big", true, false],
     control: { type: "select" },
   },
   airports: {
     options: ["sfo", "slc", "prg"],
+    control: { type: "check" },
+  },
+};
+
+export const Initial: Story<{
+  variant: string;
+  airports: string[];
+  cities: string[];
+  empty: string;
+  countries: string;
+  food: string;
+}> = ({ variant, airports, cities, empty, countries, food }) => (
+  <div id="content">
+    <p>Variant: {variant}</p>
+    <p>Airport: {airports}</p>
+    <p>Country: {countries}</p>
+    <p>Empty: {empty}</p>
+    <p>City: {cities}</p>
+    <p>Food: {food}</p>
+  </div>
+);
+
+Initial.args = {
+  variant: "secondary",
+};
+
+Initial.argTypes = {
+  variant: {
+    options: ["primary", "secondary"],
+    control: { type: "radio" },
+    defaultValue: "primary",
+  },
+  food: {
+    options: ["burger", "pizza"],
+    control: { type: "radio" },
+  },
+  airports: {
+    options: ["sfo", "slc", "prg"],
+    control: { type: "check" },
+    defaultValue: ["slc"],
+  },
+  countries: {
+    options: ["USA", "Germany"],
+    control: { type: "select" },
+  },
+  empty: {
     control: { type: "check" },
   },
 };

--- a/e2e/addons/tests/controls.spec.ts
+++ b/e2e/addons/tests/controls.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test("default control values", async ({ page }) => {
   await page.goto("http://localhost:61100/?story=controls--controls");
   await expect(page.locator("#content")).toHaveText(
-    "Count: 2Disabled: noLabel: Hello worldColors: Red,BlueVariant: primarySize: smallvariant is stringsize is string",
+    "Count: 2Disabled: noLabel: Hello worldColors: Red,BlueVariant: primarySize: variant is stringsize is undefined",
   );
 });
 
@@ -49,14 +49,14 @@ test("radio control works", async ({ page }) => {
   await expect(page.locator("#content")).toContainText("variant is string");
 });
 
-test("radio control non-string types work", async ({ page }) => {
+test("radio control boolean type works", async ({ page }) => {
   await page.goto("http://localhost:61100/?story=controls--controls");
   const button = await page.locator('[data-testid="addon-control"]');
   await button.click();
   await page.check("#variant-false");
   await expect(page.locator("#content")).toContainText("variant is boolean");
-  await page.check("#variant-undefined");
-  await expect(page.locator("#content")).toContainText("variant is undefined");
+  await page.check("#variant-secondary");
+  await expect(page.locator("#content")).toContainText("variant is string");
   await page.check("#variant-true");
   await expect(page.locator("#content")).toContainText("variant is boolean");
 });
@@ -69,14 +69,14 @@ test("select control works", async ({ page }) => {
   await expect(page.locator("#content")).toContainText("Size: big");
 });
 
-test("select control non-string types work", async ({ page }) => {
+test("select control boolean type work", async ({ page }) => {
   await page.goto("http://localhost:61100/?story=controls--controls");
   const button = await page.locator('[data-testid="addon-control"]');
   await button.click();
   await page.selectOption("select#size", "false");
   await expect(page.locator("#content")).toContainText("size is boolean");
-  await page.selectOption("select#size", "undefined");
-  await expect(page.locator("#content")).toContainText("size is undefined");
+  await page.selectOption("select#size", "medium");
+  await expect(page.locator("#content")).toContainText("size is string");
   await page.selectOption("select#size", "true");
   await expect(page.locator("#content")).toContainText("size is boolean");
 });
@@ -91,6 +91,13 @@ test("check control works", async ({ page }) => {
   await expect(page.locator("#content")).toContainText("Airport: sfoslc");
   await page.check("#airports-slc");
   await expect(page.locator("#content")).toContainText("Airport: sfo");
+});
+
+test("set defaults and args inheritence works", async ({ page }) => {
+  await page.goto("http://localhost:61100/?story=controls--initial");
+  await expect(page.locator("#content")).toHaveText(
+    "Variant: secondaryAirport: slcCountry: Empty: City: Food:",
+  );
 });
 
 test("controls state is passed through the URL", async ({ page }) => {
@@ -116,7 +123,7 @@ test("reset to defaults", async ({ page }) => {
   );
   await resetButton.click();
   await expect(page.locator("#content")).toHaveText(
-    "Count: 2Disabled: noLabel: Hello worldColors: Red,BlueVariant: primarySize: smallvariant is stringsize is string",
+    "Count: 2Disabled: noLabel: Hello worldColors: Red,BlueVariant: primarySize: variant is stringsize is undefined",
   );
 });
 

--- a/packages/example/src/controls.stories.tsx
+++ b/packages/example/src/controls.stories.tsx
@@ -36,12 +36,12 @@ Controls.args = {
 };
 Controls.argTypes = {
   variant: {
-    options: [undefined, "primary", "secondary"],
+    options: ["primary", "secondary"],
     control: { type: "radio" },
     defaultValue: "primary",
   },
   size: {
-    options: [undefined, "small", "medium", "big", "huuuuge"],
+    options: ["small", "medium", "big", "huuuuge"],
     control: { type: "select" },
   },
   onClick: {

--- a/packages/ladle/lib/app/src/addons/control.tsx
+++ b/packages/ladle/lib/app/src/addons/control.tsx
@@ -34,9 +34,6 @@ const getInputValue = (target: HTMLInputElement, type?: ControlType) => {
 };
 
 const coerceString = (value: string) => {
-  if (value === "undefined") {
-    return undefined;
-  }
   const isBoolean = value === "true" || value === "false";
   return isBoolean ? (value === "false" ? false : true) : value;
 };
@@ -140,10 +137,7 @@ const Control = ({
         >
           {(globalState.control[controlKey].options || []).map((option) => {
             const value = globalState.control[controlKey].value;
-            const isChecked =
-              value === option ||
-              value === String(option) ||
-              (typeof option === "undefined" && typeof value === "undefined");
+            const isChecked = value === option || value === String(option);
             return (
               <div
                 key={`${String(option)}-${controlKey}`}
@@ -275,10 +269,11 @@ const Control = ({
               });
             }}
           >
+            <option value="undefined" disabled>
+              Choose option...
+            </option>
             {(globalState.control[controlKey].options || []).map((option) => (
-              <option key={`${option}-${controlKey}`} value={String(option)}>
-                {String(option)}
-              </option>
+              <option key={`${option}-${controlKey}`}>{String(option)}</option>
             ))}
           </select>
         </td>

--- a/packages/ladle/lib/app/src/args-provider.tsx
+++ b/packages/ladle/lib/app/src/args-provider.tsx
@@ -89,44 +89,15 @@ const ArgsProvider = ({
             )} argTypes are supported now. For strings, booleans and numbers use just args.`,
           );
         }
+        controls[argKey] = {
+          type: argValue.control.type,
+          defaultValue: args[argKey] ? args[argKey] : argValue.defaultValue,
+          options: argValue.options,
+          value: args[argKey] ? args[argKey] : argValue.defaultValue,
+          description: argValue.description || argKey,
+        };
         if (globalState.control[argKey]) {
-          controls[argKey] = {
-            type: argValue.control.type,
-            defaultValue:
-              typeof argValue.defaultValue === "undefined"
-                ? argValue.options[0]
-                : argValue.defaultValue,
-            value: globalState.control[argKey].value,
-            options: argValue.options,
-            description: "",
-          };
-        } else {
-          controls[argKey] = {
-            type: argValue.control.type,
-            defaultValue:
-              typeof argValue.defaultValue === "undefined"
-                ? argValue.options[0]
-                : argValue.defaultValue,
-            options: argValue.options,
-            value:
-              typeof argValue.defaultValue === "undefined"
-                ? argValue.options[0]
-                : argValue.defaultValue,
-            description: argValue.name || argKey,
-          };
-          // for checkboxes set defaultValue/value to [] if not set
-          if (
-            ["check", "inline-check", "multi-select"].includes(
-              argValue.control.type,
-            )
-          ) {
-            if (typeof argValue.defaultValue === "undefined") {
-              controls[argKey].defaultValue = [];
-            }
-            if (typeof argValue.value === "undefined") {
-              controls[argKey].value = controls[argKey].defaultValue;
-            }
-          }
+          controls[argKey].value = globalState.control[argKey].value;
         }
       });
     if (Object.keys(controls).length) {


### PR DESCRIPTION
fixes #320,#318

The initial implementation was trying to be more strict/smart. This reverts to `undefined` as the default for all controls so it works the same way as Storybook's implementation.