### PR TITLE
Preventing Vite to serve files outside of root workspace.

### DIFF
--- a/.changeset/hip-roses-yawn.md
+++ b/.changeset/hip-roses-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Preventing Vite to serve files outside of root workspace. The dev server also doens't autobind to all network interfaces (aligned with the Vite's default).

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -62,7 +62,11 @@ const bundler = async (config, configFolder) => {
     }:${port}${vite.config.base || ""}`;
     app.listen(
       port,
-      vite.config.server.host ? vite.config.server.host : "localhost",
+      vite.config.server.host === true
+        ? "0.0.0.0"
+        : typeof vite.config.server.host === "string"
+        ? vite.config.server.host
+        : "localhost",
       async () => {
         console.log(
           boxen(`🥄 Ladle.dev served at ${serverUrl}`, {

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -34,9 +34,6 @@ const bundler = async (config, configFolder) => {
         hmr: {
           port: hmrPort,
         },
-        fs: {
-          strict: false,
-        },
         middlewareMode: true,
       },
     });
@@ -63,26 +60,30 @@ const bundler = async (config, configFolder) => {
     const serverUrl = `${vite.config.server.https ? "https" : "http"}://${
       vite.config.server.host || "localhost"
     }:${port}${vite.config.base || ""}`;
-    app.listen(port, async () => {
-      console.log(
-        boxen(`🥄 Ladle.dev served at ${serverUrl}`, {
-          padding: 1,
-          margin: 1,
-          borderStyle: "round",
-          borderColor: "yellow",
-          titleAlignment: "center",
-          textAlignment: "center",
-        }),
-      );
+    app.listen(
+      port,
+      vite.config.server.host ? vite.config.server.host : "localhost",
+      async () => {
+        console.log(
+          boxen(`🥄 Ladle.dev served at ${serverUrl}`, {
+            padding: 1,
+            margin: 1,
+            borderStyle: "round",
+            borderColor: "yellow",
+            titleAlignment: "center",
+            textAlignment: "center",
+          }),
+        );
 
-      if (
-        vite.config.server.open !== "none" &&
-        vite.config.server.open !== false
-      ) {
-        const browser = /** @type {string} */ (vite.config.server.open);
-        await openBrowser(serverUrl, browser);
-      }
-    });
+        if (
+          vite.config.server.open !== "none" &&
+          vite.config.server.open !== false
+        ) {
+          const browser = /** @type {string} */ (vite.config.server.open);
+          await openBrowser(serverUrl, browser);
+        }
+      },
+    );
 
     // trigger full reload when new stories are added or removed
     const watcher = chokidar.watch(config.stories, {


### PR DESCRIPTION
This is a security issue when local developing on shared network.

The dev server also doens't autobind to all network interfaces (aligned with the Vite's default).