### PR TITLE
Allow vite to access files in project workspace

### DIFF
--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -1,4 +1,4 @@
-import { createServer } from "vite";
+import { createServer, searchForWorkspaceRoot } from "vite";
 import express from "express";
 import getPort from "get-port";
 import { globby } from "globby";
@@ -34,6 +34,7 @@ const bundler = async (config, configFolder) => {
         hmr: {
           port: hmrPort,
         },
+        fs: { allow: [searchForWorkspaceRoot(process.cwd())] },
         middlewareMode: true,
       },
     });


### PR DESCRIPTION
From Discord: 

I've got some trouble using config from .ladle now though (when running ladle dev), and was wondering if someone already has a workaround for that or could point me to some adjustment for it?

I'm getting errors like these:

The request url "/Users/…/dev/app/.ladle/components.tsx" is outside of Vite serving allow list.
The request url "/Users/…/dev/app/.ladle/config.mjs" is outside of Vite serving allow list.

I think with the changes relating to https://github.com/tajo/ladle/blob/433f1243c19ee0a54a923c2881bd3dab52752dc4/packages/ladle/lib/cli/vite-dev.js#L30-L39  it is now necessary to set some server.fs.allow or something like it in the viteConfig. Hence I'm currently looking at https://github.com/tajo/ladle/blob/433f1243c19ee0a54a923c2881bd3dab52752dc4/packages/ladle/lib/cli/vite-base.js#L15.
It might also be an issue with the paths for config being available in the frontend behind @fs/absolute-path-to-file.


Using the example described at [1], this patch enables vite to serve files from the project directory with the local fileserver. Without it files from the .ladle directory are not accessible in the browser and subsequent errors are thrown.

[1]: https://vitejs.dev/config/server-options.html#server-fs-allow