### PR TITLE
feat: range control

### DIFF
--- a/.changeset/late-mirrors-pull.md
+++ b/.changeset/late-mirrors-pull.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": minor
+---
+
+range type control added

--- a/e2e/addons/package.json
+++ b/e2e/addons/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.32",
   "license": "MIT",
   "private": true,
+  "type": "module",
   "scripts": {
     "serve": "ladle serve -p 61100",
     "serve-prod": "ladle preview -p 61100",
@@ -17,6 +18,7 @@
     "@playwright/test": "^1.30.0",
     "axe-playwright": "^1.1.12",
     "playwright-core": "^1.30.0",
+    "query-string": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "start-server-and-test": "^1.15.3"

--- a/e2e/addons/playwright.config.ts
+++ b/e2e/addons/playwright.config.ts
@@ -1,0 +1,4 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {};
+export default config;

--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -16,9 +16,20 @@ export const Controls: Story<{
   colors: string[];
   variant: string;
   size: string;
+  range: number;
   airports: string;
   cities: string;
-}> = ({ count, disabled, label, colors, variant, size, airports, cities }) => (
+}> = ({
+  count,
+  disabled,
+  label,
+  colors,
+  variant,
+  size,
+  range,
+  airports,
+  cities,
+}) => (
   <div id="content">
     <p>Count: {count}</p>
     <p>Disabled: {disabled ? "yes" : "no"}</p>
@@ -26,6 +37,7 @@ export const Controls: Story<{
     <p>Colors: {colors.join(",")}</p>
     <p>Variant: {variant}</p>
     <p>Size: {size}</p>
+    <p>Range: {range}</p>
     {airports && airports.length ? <p>Airport: {airports}</p> : ""}
     {cities && cities.length ? <p>Cities: {cities}</p> : ""}
     {typeof variant === "undefined" && <p>variant is undefined</p>}
@@ -56,6 +68,10 @@ Controls.argTypes = {
   airports: {
     options: ["sfo", "slc", "prg"],
     control: { type: "check" },
+  },
+  range: {
+    control: { type: "range", min: 1, max: 10, step: 0.5 },
+    defaultValue: 1,
   },
 };
 

--- a/e2e/addons/tests/controls.spec.ts
+++ b/e2e/addons/tests/controls.spec.ts
@@ -1,9 +1,20 @@
 import { test, expect } from "@playwright/test";
+import queryString from "query-string";
 
 test("default control values", async ({ page }) => {
   await page.goto("http://localhost:61100/?story=controls--controls");
   await expect(page.locator("#content")).toHaveText(
-    "Count: 2Disabled: noLabel: Hello worldColors: Red,BlueVariant: primarySize: variant is stringsize is undefined",
+    [
+      "Count: 2",
+      "Disabled: no",
+      "Label: Hello world",
+      "Colors: Red,Blue",
+      "Variant: primary",
+      "Size: ",
+      "Range: 1",
+      "variant is string",
+      "size is undefined",
+    ].join(""),
   );
 });
 
@@ -30,6 +41,20 @@ test("number control works", async ({ page }) => {
   await button.click();
   await page.fill("#count", "5");
   await expect(page.locator("#content")).toContainText("Count: 5");
+});
+
+test("range control works", async ({ page }) => {
+  await page.goto("http://localhost:61100/?story=controls--controls");
+  const button = await page.locator('[data-testid="addon-control"]');
+  await button.click();
+  const rangeControl = await page.locator(
+    '[data-testid="ladle-dialog"] >> tr:has(:text("range"))',
+  );
+  await expect(rangeControl).toContainText("1");
+  await expect(rangeControl).toContainText("1 / 10");
+  await page.fill("#range", "5.5");
+  await expect(page.locator("#content")).toContainText("Range: 5.5");
+  await expect(rangeControl).toContainText("5.5 / 10");
 });
 
 test("string control works", async ({ page }) => {
@@ -102,19 +127,55 @@ test("set defaults and args inheritence works", async ({ page }) => {
 
 test("controls state is passed through the URL", async ({ page }) => {
   await page.goto(
-    "http://localhost:61100/?arg-disabled=true&arg-colors=%255B%2522Red%2522%2C%2522Green%2522%255D&arg-size=medium&arg-count=3&arg-variant=false&arg-label=Hello%20earth&story=controls--controls",
+    `http://localhost:61100/?story=controls--controls&${queryString.stringify({
+      "arg-count": 3,
+      "arg-disabled": true,
+      "arg-label": "Hello earth",
+      "arg-colors": '["Red","Green"]',
+      "arg-variant": false,
+      "arg-size": "medium",
+      "arg-range": 10,
+    })}`,
   );
   await expect(page.locator("#content")).toHaveText(
-    "Count: 3Disabled: yesLabel: Hello earthColors: Red,GreenVariant: Size: mediumvariant is booleansize is string",
+    [
+      "Count: 3",
+      "Disabled: yes",
+      "Label: Hello earth",
+      "Colors: Red,Green",
+      "Variant: ",
+      "Size: medium",
+      "Range: 10",
+      "variant is boolean",
+      "size is string",
+    ].join(""),
   );
 });
 
 test("reset to defaults", async ({ page }) => {
   await page.goto(
-    "http://localhost:61100/?arg-disabled=true&arg-colors=%255B%2522Red%2522%2C%2522Green%2522%255D&arg-size=medium&arg-count=3&arg-variant=secondary&arg-label=Hello%20earth&story=controls--controls",
+    `http://localhost:61100/?story=controls--controls&${queryString.stringify({
+      "arg-count": 3,
+      "arg-disabled": true,
+      "arg-label": "Hello earth",
+      "arg-colors": '["Red","Green"]',
+      "arg-variant": "secondary",
+      "arg-size": "medium",
+      "arg-range": 10,
+    })}`,
   );
   await expect(page.locator("#content")).toHaveText(
-    "Count: 3Disabled: yesLabel: Hello earthColors: Red,GreenVariant: secondarySize: mediumvariant is stringsize is string",
+    [
+      "Count: 3",
+      "Disabled: yes",
+      "Label: Hello earth",
+      "Colors: Red,Green",
+      "Variant: secondary",
+      "Size: medium",
+      "Range: 10",
+      "variant is string",
+      "size is string",
+    ].join(""),
   );
   const button = await page.locator('[data-testid="addon-control"]');
   await button.click();
@@ -123,7 +184,17 @@ test("reset to defaults", async ({ page }) => {
   );
   await resetButton.click();
   await expect(page.locator("#content")).toHaveText(
-    "Count: 2Disabled: noLabel: Hello worldColors: Red,BlueVariant: primarySize: variant is stringsize is undefined",
+    [
+      "Count: 2",
+      "Disabled: no",
+      "Label: Hello world",
+      "Colors: Red,Blue",
+      "Variant: primary",
+      "Size: ",
+      "Range: 1",
+      "variant is string",
+      "size is undefined",
+    ].join(""),
   );
 });
 

--- a/packages/example/src/controls.stories.tsx
+++ b/packages/example/src/controls.stories.tsx
@@ -9,7 +9,8 @@ export const Controls: Story<{
   colors: string[];
   variant: string;
   size: string;
-}> = ({ count, disabled, label, colors, variant, size, onClick }) => {
+  range: number;
+}> = ({ count, disabled, label, colors, variant, size, range, onClick }) => {
   if (count > 2) {
     return <p>done</p>;
   }
@@ -21,6 +22,7 @@ export const Controls: Story<{
       <p>Colors: {colors.join(",")}</p>
       <p>Variant: {variant}</p>
       <p>Size: {size}</p>
+      <p>Range: {range}</p>
       <button onClick={onClick}>Click</button>
       <button onClick={action("second")}>Second button</button>
       <button onClick={linkTo("a11y--issues")}>Link button</button>
@@ -43,6 +45,10 @@ Controls.argTypes = {
   size: {
     options: ["small", "medium", "big", "huuuuge"],
     control: { type: "select" },
+  },
+  range: {
+    control: { type: "range", min: 10, step: 0.5 },
+    defaultValue: 10,
   },
   onClick: {
     action: "clicked",

--- a/packages/ladle/lib/app/ladle.css
+++ b/packages/ladle/lib/app/ladle.css
@@ -270,6 +270,12 @@ body {
   color: var(--ladle-color-primary);
 }
 
+.ladle-addon-modal-body input[type="range"] {
+  padding: 0;
+  margin: 0 0.5em;
+  vertical-align: middle;
+}
+
 .ladle-addon-modal-body > button:hover {
   color: #ccc;
 }

--- a/packages/ladle/lib/app/src/addons/control.tsx
+++ b/packages/ladle/lib/app/src/addons/control.tsx
@@ -5,10 +5,10 @@ import queryString from "query-string";
 import type { AddonProps } from "../../../shared/types";
 import {
   ActionType,
-  ControlType,
-  GlobalState,
-  GlobalAction,
   ControlState,
+  ControlType,
+  GlobalAction,
+  GlobalState,
 } from "../../../shared/types";
 
 const getInputType = (type?: ControlType) => {
@@ -17,6 +17,8 @@ const getInputType = (type?: ControlType) => {
       return "checkbox";
     case ControlType.Number:
       return "number";
+    case ControlType.Range:
+      return "range";
     default:
       return "text";
   }
@@ -27,7 +29,8 @@ const getInputValue = (target: HTMLInputElement, type?: ControlType) => {
     case ControlType.Boolean:
       return target.checked;
     case ControlType.Number:
-      return parseInt(target.value, 10);
+    case ControlType.Range:
+      return parseFloat(target.value);
     default:
       return target.value;
   }
@@ -102,6 +105,8 @@ const Control = ({
   globalState: GlobalState;
   dispatch: React.Dispatch<GlobalAction>;
 }) => {
+  const controlState = globalState.control[controlKey];
+
   if (globalState.control[controlKey].type === ControlType.Action) {
     return (
       <tr>
@@ -310,6 +315,44 @@ const Control = ({
               });
             }}
           />
+        </td>
+      </tr>
+    );
+  }
+  if (controlState.type === ControlType.Range) {
+    // the fallback values are based on the standard range validation defaults,
+    // see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#validation
+    const displayMin = controlState.min ?? 0;
+    const displayMax = controlState.max ?? 100;
+
+    return (
+      <tr>
+        <td>
+          <label htmlFor={controlKey}>{controlKey}</label>
+        </td>
+        <td>
+          {displayMin}
+          <input
+            id={controlKey}
+            type={getInputType(controlState.type)}
+            value={controlState.value}
+            min={controlState.min}
+            max={controlState.max}
+            step={controlState.step}
+            onChange={(e) =>
+              dispatch({
+                type: ActionType.UpdateControl,
+                value: {
+                  ...globalState.control,
+                  [controlKey]: {
+                    ...controlState,
+                    value: getInputValue(e.target, controlState.type),
+                  },
+                },
+              })
+            }
+          />
+          {controlState.value} / {displayMax}
         </td>
       </tr>
     );

--- a/packages/ladle/lib/app/src/args-provider.tsx
+++ b/packages/ladle/lib/app/src/args-provider.tsx
@@ -10,6 +10,7 @@ const ALLOWED_ARGTYPES = [
   "inline-radio",
   "check",
   "inline-check",
+  "range",
 ];
 
 const ArgsProvider = ({
@@ -93,6 +94,9 @@ const ArgsProvider = ({
           options: argValue.options,
           value: args[argKey] ? args[argKey] : argValue.defaultValue,
           description: argValue.description || argKey,
+          min: argValue.control.min,
+          max: argValue.control.max,
+          step: argValue.control.step,
         };
         if (globalState.control[argKey]) {
           controls[argKey].value = globalState.control[argKey].value;

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -31,12 +31,16 @@ export enum ControlType {
   Check = "check",
   InlineCheck = "inline-check",
   Action = "action",
+  Range = "range",
 }
 
 export type ControlState = {
   [key: string]: {
     description?: string;
     defaultValue?: any;
+    max?: number;
+    min?: number;
+    step?: number;
     options?: string[];
     value: any;
     type?: ControlType;

--- a/packages/website/docs/controls.md
+++ b/packages/website/docs/controls.md
@@ -12,13 +12,15 @@ export const Controls: Story<{
   label: string;
   disabled: boolean;
   count: number;
+  range: number;
   colors: string[];
   variant: string;
   size: string;
   airpots: string[];
-}> = ({ count, disabled, label, colors, variant, size, airports }) => (
+}> = ({ count, range, disabled, label, colors, variant, size, airports }) => (
   <>
     <p>Count: {count}</p>
+    <p>Range: {range}</p>
     <p>Disabled: {disabled ? "yes" : "no"}</p>
     <p>Label: {label}</p>
     <p>Colors: {colors.join(",")}</p>
@@ -47,6 +49,10 @@ Controls.argTypes = {
   airports: {
     options: ["sfo", "slc", "prg"],
     control: { type: "check" }, // or type: inline-check
+  },
+  range: {
+    control: { type: "range", min: 1, max: 10, step: 0.5 },
+    defaultValue: 5,
   },
 };
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,7 @@ importers:
       "@playwright/test": ^1.30.0
       axe-playwright: ^1.1.12
       playwright-core: ^1.30.0
+      query-string: ^8.1.0
       react: ^18.2.0
       react-dom: ^18.2.0
       start-server-and-test: ^1.15.3
@@ -57,6 +58,7 @@ importers:
       "@playwright/test": 1.30.0
       axe-playwright: 1.1.12
       playwright-core: 1.30.0
+      query-string: 8.1.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       start-server-and-test: 1.15.3


### PR DESCRIPTION
Adds a new range type control which should be Storybook compatible.

Tests, updated docs, and changelog included. Hopefully, I didn't forget anything, if so let me know.