### PR TITLE
Improved type safety in `args`, `argTypes` and `meta` in Stories

### DIFF
--- a/.changeset/five-avocados-bow.md
+++ b/.changeset/five-avocados-bow.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Improved type safety in `args`, `argTypes` and `meta` in Stories

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -72,10 +72,18 @@ export type Args<
   },
 > = Partial<P>;
 
+export type ControlType =
+  | "select"
+  | "multi-select"
+  | "radio"
+  | "inline-radio"
+  | "check"
+  | "inline-check";
+
 export interface ArgType<K = any> {
   control?: {
     options?: K[];
-    type: string;
+    type: ControlType;
     [key: string]: any;
   };
   defaultValue?: any;

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -72,10 +72,15 @@ export type Args<
   },
 > = Partial<P>;
 
-export interface ArgType {
-  name?: string;
-  description?: string;
+export interface ArgType<K = any> {
+  control?: {
+    options?: K[];
+    type: string;
+    [key: string]: any;
+  };
   defaultValue?: any;
+  description?: string;
+  name?: string;
   [key: string]: any;
 }
 
@@ -84,5 +89,5 @@ export type ArgTypes<
     [key: string]: any;
   },
 > = {
-  [key in keyof P]?: ArgType;
+  [key in keyof P]?: ArgType<P[key]>;
 };

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -54,13 +54,13 @@ export type GlobalProvider = React.FC<{
   dispatch: React.Dispatch<GlobalAction>;
   config: Config;
   children: ReactNodeWithoutObject;
-  storyMeta?: any;
+  storyMeta?: Meta;
 }>;
 
 export interface Story<P = {}> extends React.FC<P> {
   storyName?: string;
   parameters?: any;
-  meta?: any;
+  meta?: Meta;
   args?: Args<P>;
   argTypes?: ArgTypes<P>;
   decorators?: StoryDecorator[];
@@ -98,4 +98,8 @@ export type ArgTypes<
   },
 > = {
   [key in keyof P]?: ArgType<P[key]>;
+};
+
+export type Meta = {
+  [key: string]: any;
 };

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -58,12 +58,11 @@ export type GlobalProvider = React.FC<{
 }>;
 
 export interface Story<P = {}> extends React.FC<P> {
-  storyName?: string;
-  parameters?: any;
-  meta?: Meta;
   args?: Args<P>;
   argTypes?: ArgTypes<P>;
   decorators?: StoryDecorator[];
+  meta?: Meta;
+  storyName?: string;
 }
 
 export type Args<

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -86,7 +86,7 @@ export interface ArgType<K = any> {
     type: ControlType;
     [key: string]: any;
   };
-  defaultValue?: any;
+  defaultValue?: K;
   description?: string;
   name?: string;
   [key: string]: any;

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -61,13 +61,16 @@ export interface Story<P = {}> extends React.FC<P> {
   storyName?: string;
   parameters?: any;
   meta?: any;
-  args?: Args;
-  argTypes?: ArgTypes;
+  args?: Args<P>;
+  argTypes?: ArgTypes<P>;
   decorators?: StoryDecorator[];
 }
-export interface Args {
-  [key: string]: any;
-}
+
+export type Args<
+  P = {
+    [key: string]: any;
+  },
+> = Partial<P>;
 
 export interface ArgType {
   name?: string;
@@ -76,6 +79,10 @@ export interface ArgType {
   [key: string]: any;
 }
 
-export interface ArgTypes {
-  [key: string]: ArgType;
-}
+export type ArgTypes<
+  P = {
+    [key: string]: any;
+  },
+> = {
+  [key in keyof P]?: ArgType;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,8 @@
     "packages/*/lib/**/*",
     "packages/*/src/**/*",
     "e2e/*/src/*",
-    "e2e/*/tests/*"
+    "e2e/*/tests/*",
+    "type-tests/*"
   ],
   "exclude": [
     "packages/website/**",

--- a/type-tests/argTypes.test.tsx
+++ b/type-tests/argTypes.test.tsx
@@ -13,6 +13,29 @@ Types.argTypes = {
   foo: {
     control: {
       type: "select",
+      options: [
+        "foo",
+        // @ts-expect-error - 1 is not a string
+        5,
+      ],
+    },
+  },
+  bar: {
+    control: {
+      type: "select",
+      options: [1, 2, 3],
+    },
+  },
+};
+
+export const Types2: Story<FooProps> = ({ foo, bar }) => {
+  return <div>{foo + bar}</div>;
+};
+
+Types2.argTypes = {
+  foo: {
+    control: {
+      type: "select",
       options: ["foo", "bar"],
     },
   },
@@ -23,5 +46,7 @@ Types.argTypes = {
     },
   },
   // @ts-expect-error - baz is not a valid arg
-  baz: {},
+  baz: {
+    control: {},
+  },
 };

--- a/type-tests/argTypes.test.tsx
+++ b/type-tests/argTypes.test.tsx
@@ -5,11 +5,13 @@ type FooProps = {
   bar: number;
 };
 
-export const Types: Story<FooProps> = ({ foo, bar }) => {
+function Foo({ foo, bar }: FooProps) {
   return <div>{foo + bar}</div>;
-};
+}
 
-Types.argTypes = {
+export const ArgTypes: Story<FooProps> = Foo;
+
+ArgTypes.argTypes = {
   foo: {
     control: {
       type: "select",
@@ -28,11 +30,9 @@ Types.argTypes = {
   },
 };
 
-export const Types2: Story<FooProps> = ({ foo, bar }) => {
-  return <div>{foo + bar}</div>;
-};
+export const ArgTypes2: Story<FooProps> = Foo;
 
-Types2.argTypes = {
+ArgTypes2.argTypes = {
   foo: {
     control: {
       type: "select",
@@ -51,11 +51,9 @@ Types2.argTypes = {
   },
 };
 
-export const Types3: Story<FooProps> = ({ foo, bar }) => {
-  return <div>{foo + bar}</div>;
-};
+export const ArgTypes3: Story<FooProps> = Foo;
 
-Types3.argTypes = {
+ArgTypes3.argTypes = {
   foo: {
     control: {
       // @ts-expect-error - type is not a valid control type
@@ -64,11 +62,11 @@ Types3.argTypes = {
   },
 };
 
-export const Types4: Story<FooProps> = ({ foo, bar }) => {
+export const ArgTypes4: Story<FooProps> = ({ foo, bar }) => {
   return <div>{foo + bar}</div>;
 };
 
-Types4.argTypes = {
+ArgTypes4.argTypes = {
   foo: {
     control: {
       type: "select",

--- a/type-tests/argTypes.test.tsx
+++ b/type-tests/argTypes.test.tsx
@@ -50,3 +50,16 @@ Types2.argTypes = {
     control: {},
   },
 };
+
+export const Types3: Story<FooProps> = ({ foo, bar }) => {
+  return <div>{foo + bar}</div>;
+};
+
+Types3.argTypes = {
+  foo: {
+    control: {
+      // @ts-expect-error - type is not a valid control type
+      type: "potato",
+    },
+  },
+};

--- a/type-tests/argTypes.test.tsx
+++ b/type-tests/argTypes.test.tsx
@@ -1,0 +1,27 @@
+import type { Story } from "../packages/ladle/lib/app/exports";
+
+type FooProps = {
+  foo: string;
+  bar: number;
+};
+
+export const Types: Story<FooProps> = ({ foo, bar }) => {
+  return <div>{foo + bar}</div>;
+};
+
+Types.argTypes = {
+  foo: {
+    control: {
+      type: "select",
+      options: ["foo", "bar"],
+    },
+  },
+  bar: {
+    control: {
+      type: "select",
+      options: [1, 2, 3],
+    },
+  },
+  // @ts-expect-error - baz is not a valid arg
+  baz: {},
+};

--- a/type-tests/argTypes.test.tsx
+++ b/type-tests/argTypes.test.tsx
@@ -63,3 +63,18 @@ Types3.argTypes = {
     },
   },
 };
+
+export const Types4: Story<FooProps> = ({ foo, bar }) => {
+  return <div>{foo + bar}</div>;
+};
+
+Types4.argTypes = {
+  foo: {
+    control: {
+      type: "select",
+      options: ["foo", "bar"],
+    },
+    // @ts-expect-error - defaultValue is not a string
+    defaultValue: 5,
+  },
+};

--- a/type-tests/args.test.tsx
+++ b/type-tests/args.test.tsx
@@ -1,0 +1,16 @@
+import type { Story } from "../packages/ladle/lib/app/exports";
+
+type FooProps = {
+  foo: string;
+  bar: number;
+};
+
+export const Types: Story<FooProps> = ({ foo, bar }) => {
+  return <div>{foo + bar}</div>;
+};
+
+Types.args = {
+  foo: "foo",
+  // @ts-expect-error - bar is not a string
+  bar: "1",
+};

--- a/type-tests/args.test.tsx
+++ b/type-tests/args.test.tsx
@@ -14,3 +14,14 @@ Types.args = {
   // @ts-expect-error - bar is not a string
   bar: "1",
 };
+
+export const Types2: Story<FooProps> = ({ foo, bar }) => {
+  return <div>{foo + bar}</div>;
+};
+
+Types2.args = {
+  foo: "foo",
+  bar: 1,
+  // @ts-expect-error - baz is not a valid arg
+  baz: "baz",
+};

--- a/type-tests/args.test.tsx
+++ b/type-tests/args.test.tsx
@@ -5,21 +5,21 @@ type FooProps = {
   bar: number;
 };
 
-export const Types: Story<FooProps> = ({ foo, bar }) => {
+function Foo({ foo, bar }: FooProps) {
   return <div>{foo + bar}</div>;
-};
+}
 
-Types.args = {
+export const Args: Story<FooProps> = Foo;
+
+Args.args = {
   foo: "foo",
   // @ts-expect-error - bar is not a string
   bar: "1",
 };
 
-export const Types2: Story<FooProps> = ({ foo, bar }) => {
-  return <div>{foo + bar}</div>;
-};
+export const Args2: Story<FooProps> = Foo;
 
-Types2.args = {
+Args2.args = {
   foo: "foo",
   bar: 1,
   // @ts-expect-error - baz is not a valid arg

--- a/type-tests/meta.test.tsx
+++ b/type-tests/meta.test.tsx
@@ -1,0 +1,19 @@
+import type { Story } from "../packages/ladle/lib/app/exports";
+
+type FooProps = {
+  foo: string;
+  bar: number;
+};
+
+function Foo({ foo, bar }: FooProps) {
+  return <div>{foo + bar}</div>;
+}
+
+export const Meta: Story<FooProps> = Foo;
+
+// @ts-expect-error - meta is not a valid arg
+Meta.meta = "foo";
+
+export const Meta2: Story<FooProps> = Foo;
+
+Meta2.meta = {};


### PR DESCRIPTION
Uses `P` passed to `Story<>` to enhance `Args` and `ArgTypes` so that `args` can only contain key/value pairs defined in `P`, and `argTypes` can only contain keys defined in `P`.

Improves `ArgType` type to include checks for `control` that now checks for `type` and `options` validity, and for `defaultValue`.

Adds very basic `Meta` type.

Adds `type-tests` which are files that are built to deliberately trigger type errors - then marks them with `@ts-expect-error` so that:
* Any unmarked type error triggers an error
* Any marked type error which is NOT triggered triggers an error

Before:
<img width="1464" alt="Zrzut ekranu 2023-02-9 o 09 42 05" src="https://user-images.githubusercontent.com/5426427/217763121-0225de90-d5ea-43ce-9a38-e3b9357e37e6.png">


After:
<img width="1465" alt="Zrzut ekranu 2023-02-9 o 09 42 23" src="https://user-images.githubusercontent.com/5426427/217763107-496fe153-dd60-4a73-8ba6-940943bef49f.png">

`argTypes`:
<img width="782" alt="Zrzut ekranu 2023-02-9 o 09 46 15" src="https://user-images.githubusercontent.com/5426427/217763082-e6502bf8-5fc4-46d6-911c-1b8eaa278ca8.png">
