### PR TITLE
Implement type safe default export (`GlobalStory`), improve StoryDecorator type, fix errors found by TypeScript

### DIFF
--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -1,4 +1,4 @@
-import type { Story } from "@ladle/react";
+import type { GlobalStory, Story } from "@ladle/react";
 
 type Props = {
   label: string;
@@ -19,7 +19,7 @@ export default {
       control: { type: "check" },
     },
   },
-};
+} satisfies GlobalStory<Props>;
 
 export const Controls: Story<Props> = ({
   count,

--- a/e2e/decorators/src/args.stories.tsx
+++ b/e2e/decorators/src/args.stories.tsx
@@ -9,7 +9,7 @@ export default {
       return (
         <div style={{ border: "5px solid red" }}>
           <p>first {context.globalState.control.label.value}</p>
-          <Component />
+          <Component label={context.globalState.control.label.value} />
         </div>
       );
     },
@@ -18,7 +18,7 @@ export default {
       return (
         <div style={{ border: "5px solid blue" }}>
           <p>second {context.globalState.control.label.value}</p>
-          <Component />
+          <Component label={context.globalState.control.label.value} />
         </div>
       );
     },
@@ -27,7 +27,7 @@ export default {
       return (
         <div style={{ border: "5px solid green" }}>
           <p>third {context.globalState.control.label.value}</p>
-          <Component />
+          <Component label={context.globalState.control.label.value} />
         </div>
       );
     },
@@ -49,7 +49,7 @@ CardHello.decorators = [
     return (
       <div style={{ border: "5px solid pink" }}>
         <p>private {context.globalState.control.label.value}</p>
-        <Component />
+        <Component label={context.globalState.control.label.value} />
       </div>
     );
   },

--- a/e2e/decorators/src/args.stories.tsx
+++ b/e2e/decorators/src/args.stories.tsx
@@ -1,4 +1,4 @@
-import type { Story, StoryDecorator } from "@ladle/react";
+import type { GlobalStory, Story } from "@ladle/react";
 
 type Props = { label: string };
 
@@ -31,8 +31,8 @@ export default {
         </div>
       );
     },
-  ] as StoryDecorator[],
-};
+  ],
+} satisfies GlobalStory<Props>;
 
 const Card: Story<Props> = ({ label }) => (
   <>

--- a/e2e/decorators/src/hello.stories.tsx
+++ b/e2e/decorators/src/hello.stories.tsx
@@ -1,4 +1,4 @@
-import type { Story, StoryDecorator } from "@ladle/react";
+import type { GlobalStory, Story } from "@ladle/react";
 
 export default {
   decorators: [
@@ -12,8 +12,8 @@ export default {
         Decorator 2<Stories />
       </>
     ),
-  ] as StoryDecorator[],
-};
+  ],
+} satisfies GlobalStory;
 
 export const World: Story = () => {
   return <h2>world</h2>;

--- a/e2e/decorators/src/params.stories.tsx
+++ b/e2e/decorators/src/params.stories.tsx
@@ -1,4 +1,4 @@
-import type { Story } from "@ladle/react";
+import type { GlobalStory, Story } from "@ladle/react";
 
 export default {
   title: "Root / Examples",
@@ -6,7 +6,7 @@ export default {
     drink: "coke",
     food: "burger",
   },
-};
+} satisfies GlobalStory;
 
 export const First: Story = () => {
   return <h1>first</h1>;

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -57,10 +57,18 @@ export type GlobalProvider = React.FC<{
   storyMeta?: Meta;
 }>;
 
+export type GlobalStory<P = {}> = {
+  args?: Args<P>;
+  argTypes?: ArgTypes<P>;
+  decorators?: StoryDecorator<P>[];
+  meta?: Meta;
+  title?: string;
+};
+
 export interface Story<P = {}> extends React.FC<P> {
   args?: Args<P>;
   argTypes?: ArgTypes<P>;
-  decorators?: StoryDecorator[];
+  decorators?: StoryDecorator<P>[];
   meta?: Meta;
   storyName?: string;
 }
@@ -105,5 +113,7 @@ export type ArgTypes<
 };
 
 export type Meta = {
+  iframed?: boolean;
+  width?: number | "xsmall" | "small" | "medium" | "large";
   [key: string]: any;
 };

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -130,8 +130,8 @@ export type StoryProps = {
   config: Config;
 };
 
-export type StoryDecorator = (
-  Story: React.FC,
+export type StoryDecorator<P = {}> = (
+  Story: React.FC<P>,
   context: StoryProps,
 ) => React.ReactElement;
 


### PR DESCRIPTION
Not sure about the naming of this type, but couldn't come up with anything better.