### PR TITLE
Pass config.mjs values into the client through serialization and virtual module

### DIFF
--- a/.changeset/ninety-penguins-jog.md
+++ b/.changeset/ninety-penguins-jog.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Change the way how values from config.mjs are passed to the client. We were doing direct import into the app but that breaks cases when config.mjs uses Node APIs. Also, it risks leaking potentially sensitive stuff from the CLI side. And it's cubersome when used through programatic API / wrapper libraries. The new solution picks just a subset of config.mjs values that are really needed in the client, serializes them and embeds them into our virtual module.

--- a/e2e/programmatic/.ladle/config.mjs
+++ b/e2e/programmatic/.ladle/config.mjs
@@ -1,3 +1,0 @@
-export default {
-  port: 61105,
-};

--- a/e2e/programmatic/build.js
+++ b/e2e/programmatic/build.js
@@ -1,3 +1,5 @@
 import build from "@ladle/react/build";
 
-build();
+build({
+  port: 61105,
+});

--- a/e2e/programmatic/serve.js
+++ b/e2e/programmatic/serve.js
@@ -1,5 +1,5 @@
 import serve from "@ladle/react/serve";
 
 serve({
-  config: ".ladle",
+  port: 61105,
 });

--- a/packages/ladle/lib/app/src/app.tsx
+++ b/packages/ladle/lib/app/src/app.tsx
@@ -85,6 +85,7 @@ const App = () => {
     }
     if (
       globalState.story &&
+      unsortedStories[globalState.story] &&
       unsortedStories[globalState.story].entry.endsWith(".mdx")
     ) {
       document.documentElement.setAttribute("data-mdx", "true");

--- a/packages/ladle/lib/app/src/get-config.ts
+++ b/packages/ladle/lib/app/src/get-config.ts
@@ -7,6 +7,9 @@ import debug from "./debug";
 if (Object.keys(config).length === 0) {
   debug("No custom config found.");
 } else {
+  if (config.storyOrder && typeof config.storyOrder === "string") {
+    config.storyOrder = new Function("return " + config.storyOrder)();
+  }
   debug(`Custom config found:`);
   debug(config);
 }

--- a/packages/ladle/lib/app/src/no-stories.tsx
+++ b/packages/ladle/lib/app/src/no-stories.tsx
@@ -1,3 +1,4 @@
+import { config } from "virtual:generated-list";
 import { Code, Link } from "./ui";
 
 const NoStories = ({
@@ -21,7 +22,7 @@ const NoStories = ({
         <h1>No stories found</h1>
         <p>
           The configured glob pattern for stories is:{" "}
-          <Code>{(import.meta as any).env.VITE_PUBLIC_STORIES}</Code>.{" "}
+          <Code>{config.stories}</Code>.{" "}
         </p>
         <p>
           It can be changed through the{" "}

--- a/packages/ladle/lib/cli/apply-cli-config.js
+++ b/packages/ladle/lib/cli/apply-cli-config.js
@@ -21,31 +21,8 @@ export default async function applyCLIConfig(params) {
     config.addons.theme.defaultState = params.theme;
     delete params.theme;
   }
-  if (params.addons || params.defaultStory || params.storyOrder) {
-    console.log(
-      boxen(
-        `These settings are not supported through the programatic API:
-
-  - addons, 
-  - defaultStory
-  - storyOrder
-
-Add them to .ladle/config.mjs instead.`,
-        {
-          padding: 1,
-          margin: 1,
-          borderStyle: "round",
-          borderColor: "red",
-          titleAlignment: "left",
-          textAlignment: "left",
-        },
-      ),
-    );
-    process.exit(1);
-  }
   merge(config, params);
   debug(`Final config:\n${JSON.stringify(config, null, "  ")}`);
   process.env["VITE_PUBLIC_LADLE_THEME"] = config.addons.theme.defaultState;
-  process.env["VITE_PUBLIC_STORIES"] = config.stories;
   return { configFolder, config };
 }

--- a/packages/ladle/lib/cli/apply-cli-config.js
+++ b/packages/ladle/lib/cli/apply-cli-config.js
@@ -2,7 +2,6 @@ import debug from "./debug.js";
 import path from "path";
 import merge from "lodash.merge";
 import loadConfig from "./load-config.js";
-import boxen from "boxen";
 
 /**
  * @param params {import("../shared/types").CLIParams}

--- a/packages/ladle/lib/cli/vite-plugin/generate/get-config-import.js
+++ b/packages/ladle/lib/cli/vite-plugin/generate/get-config-import.js
@@ -1,18 +1,38 @@
 import fs from "fs";
 import path from "path";
-import cleanupWindowsPath from "./cleanup-windows-path.js";
 
 /**
  * @param {string} configFolder
  */
-const getConfigImport = (configFolder) => {
+const getConfigImport = async (configFolder) => {
   const configPath = path.join(configFolder, "config.mjs");
   const configExists = fs.existsSync(configPath);
   let configCode = `export let config = {};\n`;
   if (configExists) {
-    configCode += `import customConfig from '${cleanupWindowsPath(
-      path.join(configFolder, "config.mjs"),
-    )}';\nconfig = customConfig;\n`;
+    const config = (await import(configPath)).default;
+    let serializedConfig = {};
+    try {
+      serializedConfig = JSON.stringify({
+        ...(config.stories ? { stories: config.stories } : {}),
+        ...(config.addons ? { addons: config.addons } : {}),
+        ...(config.defaultStory ? { defaultStory: config.defaultStory } : {}),
+        ...(config.base ? { base: config.base } : {}),
+        ...(config.mode ? { mode: config.mode } : {}),
+        ...(config.storyOrder
+          ? {
+              storyOrder: Array.isArray(config.storyOrder)
+                ? config.storyOrder
+                : config.storyOrder.toString(),
+            }
+          : {}),
+      });
+    } catch (e) {
+      console.log(
+        `config.stories, config.addons, config.defaultStory, config.base, config.mode and config.storyOrder need to be serializable.`,
+      );
+      process.exit(1);
+    }
+    configCode += `\nconfig = ${serializedConfig};\n`;
   }
   return `${configCode}`;
 };

--- a/packages/ladle/lib/cli/vite-plugin/generate/get-generated-list.js
+++ b/packages/ladle/lib/cli/vite-plugin/generate/get-generated-list.js
@@ -9,11 +9,11 @@ import getComponentsImport from "./get-components-import.js";
  * @param configFolder {string}
  * @param config {import("../../../shared/types").Config}
  */
-const getGeneratedList = (entryData, configFolder, config) => {
+const getGeneratedList = async (entryData, configFolder, config) => {
   return `
 ${getStoryImports(entryData)}
 ${getStoryList(entryData)}
-${getConfigImport(configFolder)}
+${await getConfigImport(configFolder)}
 ${getComponentsImport(configFolder)}
 ${getStorySource(entryData, config.addons.source.enabled)}
 export const errorMessage = '';\n

--- a/packages/ladle/lib/cli/vite-plugin/vite-plugin.js
+++ b/packages/ladle/lib/cli/vite-plugin/vite-plugin.js
@@ -116,7 +116,7 @@ function ladlePlugin(config, configFolder, mode) {
             ),
           );
           detectDuplicateStoryNames(entryData);
-          return getGeneratedList(entryData, configFolder, config);
+          return await getGeneratedList(entryData, configFolder, config);
         } catch (/** @type {any} */ e) {
           printError("\nStory discovering failed:\n");
           printError(e);

--- a/packages/ladle/tests/get-generated-list.test.ts
+++ b/packages/ladle/tests/get-generated-list.test.ts
@@ -5,7 +5,7 @@ import getGeneratedList from "../lib/cli/vite-plugin/generate/get-generated-list
 
 test("Single file with two stories", async () => {
   const entryData = await getEntryData(["tests/fixtures/animals.stories.tsx"]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -13,7 +13,7 @@ test("Capital letters in story names converted into delimiters", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/capitalization.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -21,7 +21,7 @@ test("Capital letters in the filename converted into delimiters", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/filenameCapitalization.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -29,7 +29,7 @@ test("Turn file name delimiters into spaces and levels correctly", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/our-animals--mammals.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -37,7 +37,7 @@ test("Default title is used instead of the file name", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/default-title.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -45,7 +45,7 @@ test("Story name replaces named export as a story name", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/storyname.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -53,7 +53,7 @@ test("Extract default meta", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/default-meta.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });
 
@@ -61,6 +61,6 @@ test("Extract and merge story meta", async () => {
   const entryData = await getEntryData([
     "tests/fixtures/story-meta.stories.tsx",
   ]);
-  const list = getGeneratedList(entryData, ".ladle", defaultConfig);
+  const list = await getGeneratedList(entryData, ".ladle", defaultConfig);
   expect(list).toMatchSnapshot();
 });

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -70,7 +70,7 @@ export default {
 
 ### defaultStory
 
-Change which story is loaded when Ladle starts. It's the `?story=` portion of URL. The default value is `""` - open the first story in alphabetical order.
+Change which story is loaded when Ladle starts. It's the `?story=` portion of URL. The default value is `""` - open the first story in alphabetical order. Must be serializable.
 
 ```tsx
 export default {
@@ -80,7 +80,7 @@ export default {
 
 ### storyOrder
 
-Change the order of stories in the navigation . By default, stories are sorted alphabetically where "folders" have priority over individual stories. You should supply an array of story IDs (as used in the URL) or a function that returns such an array.
+Change the order of stories in the navigation . By default, stories are sorted alphabetically where "folders" have priority over individual stories. You should supply an array of story IDs (as used in the URL) or a function that returns such an array. Must be serializable.
 
 #### Default setting
 
@@ -127,7 +127,7 @@ export default {
 
 ### base
 
-Base path for building the output; useful for e.g. hosting your project's storybook on GitHub Pages:
+Base path for building the output; useful for e.g. hosting your project's storybook on GitHub Pages. Must be serializable.
 
 ```tsx
 export default {
@@ -139,7 +139,7 @@ export default {
 
 Vite [mode](https://vitejs.dev/guide/env-and-mode.html#modes). If not set, defaults to `development` when developing and `production` for building static output.
 
-This also affects [Vite's .env file loading](https://vitejs.dev/guide/env-and-mode.html#env-files), as well as anything else setting `mode` affects.
+This also affects [Vite's .env file loading](https://vitejs.dev/guide/env-and-mode.html#env-files), as well as anything else setting `mode` affects. Must be serializable.
 
 ```tsx
 export default {
@@ -161,7 +161,7 @@ The same effect can be achieved by creating a file `.ladle/head.html`.
 
 ### addons
 
-You can enable or disable all Ladle addons (the buttons in the left bottom corner). You can also control their default state.
+You can enable or disable all Ladle addons (the buttons in the left bottom corner). You can also control their default state. Must be serializable.
 
 ```tsx
 export default {

--- a/packages/website/docs/programmatic.md
+++ b/packages/website/docs/programmatic.md
@@ -11,13 +11,13 @@ import build from "@ladle/react/build";
 import preview from "@ladle/react/preview";
 
 await serve({
-  config: ".ladle", // default folder for config.mjs
+  // config: {}
 });
 await build({
-  config: ".ladle", // default folder for config.mjs
+  // config: {}
 });
 await preview({
-  config: ".ladle", // default folder for config.mjs
+  // config: {}
 });
 ```
 


### PR DESCRIPTION
Change the way how values from config.mjs are passed to the client. We were doing direct import into the app but that breaks cases when config.mjs uses Node APIs. Also, it risks leaking potentially sensitive stuff from the CLI side. And it's cubersome when used through programatic API / wrapper libraries. The new solution picks just a subset of config.mjs values that are really needed in the client, serializes them and embeds them into our virtual module.