### PR TITLE
Add `--base` cli option in preview mode

### DIFF
--- a/.changeset/ten-buses-think.md
+++ b/.changeset/ten-buses-think.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Add `--base` cli option in preview mode

--- a/packages/ladle/lib/cli/vite-preview.js
+++ b/packages/ladle/lib/cli/vite-preview.js
@@ -50,7 +50,7 @@ const vitePreview = async (config, configFolder) => {
       previewServer.config.preview.https ? "https" : "http"
     }://${previewServer.config.preview.host || "localhost"}:${
       config.previewPort
-    }`;
+    }${config.base}`;
     console.log(
       boxen(`🥄 Ladle.dev previewed at ${serverUrl}`, {
         padding: 1,


### PR DESCRIPTION
The `base` cli configuration option is ignored for the preview mode using `ladle preview`. 

As pointed out in the [documentation](https://ladle.dev/docs/cli#preview-command), `--base` should be supported and initially read from the configuration folder (default `.ladle`).

So if you specify a base path, the preview just opens at the desired URL (for example *http://localhost:8080*) and then you'll get the notification:

> Cannot GET /

In my case, I have to append **/styleguide** each time manually and it looks broken on initial browser open.

```typescript
// .ladle/config.mjs
export default {
  …
  base: '/styleguide/',
};
```

Adding `config.base` to the `serverUrl` solves the issue.