### PR TITLE
Fix range value initially being a string when loading from url search params

### DIFF
--- a/.changeset/fifty-stingrays-drum.md
+++ b/.changeset/fifty-stingrays-drum.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Fix range arguments loaded from search params being strings instead of numbers

--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -42,6 +42,8 @@ export const Controls: Story<Props> = ({
     <p>Range: {range}</p>
     {airports && airports.length ? <p>Airport: {airports}</p> : ""}
     {cities && cities.length ? <p>Cities: {cities}</p> : ""}
+    {typeof count !== "number" && <p>count is not number</p>}
+    {typeof range !== "number" && <p>range is not number</p>}
     {typeof variant === "undefined" && <p>variant is undefined</p>}
     {typeof variant === "boolean" && <p>variant is boolean</p>}
     {typeof variant === "string" && <p>variant is string</p>}

--- a/packages/ladle/lib/app/src/addons/control.tsx
+++ b/packages/ladle/lib/app/src/addons/control.tsx
@@ -67,6 +67,9 @@ export const getQuery = (
           case ControlType.Boolean:
             realValue = argValue === "true";
             break;
+          case ControlType.Range:
+            realValue = parseFloat(argValue);
+            break;
           case ControlType.Number:
             realValue = parseInt(argValue, 10);
             break;


### PR DESCRIPTION
When a range type argument is stored in the url and the page is reloaded, the value is a string instead of number until the range is adjusted.