### PR TITLE
Add a --host option for serve and preview

### DIFF
--- a/.changeset/silly-flies-complain.md
+++ b/.changeset/silly-flies-complain.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Add a CLI --host option for serve and preview commands that overrides vite.config.js settings.

--- a/packages/ladle/lib/cli/apply-cli-config.js
+++ b/packages/ladle/lib/cli/apply-cli-config.js
@@ -9,6 +9,7 @@ import loadConfig from "./load-config.js";
 export default async function applyCLIConfig(params) {
   debug(`CLI theme: ${params.theme}`);
   debug(`CLI stories: ${params.stories}`);
+  debug(`CLI host: ${params.host || "undefined"}`);
   debug(`CLI port: ${params.port || "undefined"}`);
   debug(`CLI out: ${params.outDir || "undefined"}`);
   params.config = params.config || ".ladle";

--- a/packages/ladle/lib/cli/cli.js
+++ b/packages/ladle/lib/cli/cli.js
@@ -16,6 +16,7 @@ program
   .command("serve")
   .alias("dev")
   .description("start developing")
+  .option("-h, --host [string]", "host to serve the application")
   .option("-p, --port [number]", "port to serve the application", strToInt)
   .option("--stories [string]", "glob to find stories")
   .option("--theme [string]", "theme light, dark or auto")
@@ -47,13 +48,14 @@ program
   .command("preview")
   .description("start a server to preview the build in outDir")
   .option("-o, --outDir <path>", "output directory")
+  .option("-h, --host [string]", "host to serve the application")
   .option("-p, --port [number]", "port to serve the application", strToInt)
   .option("--config [string]", "folder where config is located, default .ladle")
   .option("--viteConfig [string]", "file with Vite configuration")
   .option("--base [string]", "base URL path for build output")
   .option("--mode [string]", "Vite mode")
   .action(async (params) => {
-    await preview({ ...params, previewPort: params.port });
+    await preview({ ...params, previewHost: params.host, previewPort: params.port });
   });
 
 program.parse(process.argv);

--- a/packages/ladle/lib/cli/vite-dev.js
+++ b/packages/ladle/lib/cli/vite-dev.js
@@ -34,6 +34,7 @@ const bundler = async (config, configFolder) => {
     const viteConfig = await getBaseViteConfig(config, configFolder, {
       mode: config.mode || "development",
       server: {
+        host: config.host,
         port: config.port,
         hmr: {
           port: hmrPort,
@@ -53,7 +54,7 @@ const bundler = async (config, configFolder) => {
       if (
         ctx.request.method === "GET" &&
         ctx.request.url ===
-          (redirectBase ? path.join(redirectBase, "meta.json") : "/meta.json")
+        (redirectBase ? path.join(redirectBase, "meta.json") : "/meta.json")
       ) {
         const entryData = await getEntryData(
           await globby(
@@ -88,14 +89,15 @@ const bundler = async (config, configFolder) => {
       vite.config.server.https.key &&
       vite.config.server.https.cert;
     const hostname =
-      vite.config.server.host === true
-        ? "0.0.0.0"
-        : typeof vite.config.server.host === "string"
-        ? vite.config.server.host
-        : "localhost";
-    const serverUrl = `${useHttps ? "https" : "http"}://${hostname}:${port}${
-      vite.config.base || ""
-    }`;
+      config.host ?? (
+        vite.config.server.host === true
+          ? "0.0.0.0"
+          : typeof vite.config.server.host === "string"
+            ? vite.config.server.host
+            : "localhost"
+      );
+    const serverUrl = `${useHttps ? "https" : "http"}://${hostname}:${port}${vite.config.base || ""
+      }`;
 
     const listenCallback = async () => {
       console.log(

--- a/packages/ladle/lib/cli/vite-preview.js
+++ b/packages/ladle/lib/cli/vite-preview.js
@@ -20,6 +20,7 @@ const vitePreview = async (config, configFolder) => {
         emptyOutDir: true,
       },
       preview: {
+        host: config.previewHost,
         port: config.previewPort,
       },
     });

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -169,7 +169,9 @@ export type Config = {
   storyOrder: StoryOrder;
   appendToHead: string;
   viteConfig?: string;
+  host?: string;
   port: number;
+  previewHost?: string;
   previewPort: number;
   outDir: string;
   base?: string;

--- a/packages/website/docs/cli.md
+++ b/packages/website/docs/cli.md
@@ -26,6 +26,7 @@ Usage: ladle serve|dev [options]
 start developing
 
 Options:
+  -h, --host [string]    host to serve the application
   -p, --port [number]    port to serve the application
   --stories [string]     glob to find stories
   --theme [string]       theme light, dark or auto
@@ -65,6 +66,7 @@ start a server to preview the build in outDir
 
 Options:
   -o, --outDir <path>    output directory
+  -h, --host [string]    host to serve the application
   -p, --port [number]    port to serve the application
   --config [string]      folder where config is located, default .ladle
   --viteConfig [string]  file with Vite configuration

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -38,6 +38,26 @@ export default {
 };
 ```
 
+### host
+
+Specify the dev server host.
+
+```tsx
+export default {
+  host: "0.0.0.0",
+};
+```
+
+### previewHost
+
+Specify the preview server host.
+
+```tsx
+export default {
+  previewHost: "0.0.0.0",
+};
+```
+
 ### port
 
 Specify the dev server port.


### PR DESCRIPTION
This PR adds a `--host [string]` command line option to the serve and preview commands that maps to Vite's `--host / host:` configuration parameter.

Today, the host can be configured in `vite.config.ts`, but cannot be configured per-execution. Adding a `--host` command line option allows the host to be configured per-execution.

### Use case

This parameter is useful to me when running playwright visual tests in a docker container.

When listening on 127.0.0.1 on the host (the default), the docker container cannot access Ladle. To let the container access Ladle, either Ladle must listen on an address in `docker0` or on `0.0.0.0`. There are problems with both:

- If Ladle is configured to listen on `docker0`, then it fails to bind when the `docker0` interface is unavailable, which occurs when docker is down or not installed.
- If Ladle is configured to listen on `0.0.0.0`, then it is by default accessible to external hosts unless a firewall is configured to block incoming connections.

This PR enables a setup where Ladle by default listens on 127.0.0.1, but can be configured to listen on `172.17.0.1` (an address on `docker0`) when running playwright visual tests in docker.

For additional context into my use case, I run the following commands to run visual tests locally and in CI:

```
$ docker build --tag playwright-test:latest - < playwright.Dockerfile
$ pnpm start-server-and-test \
    'pnpm ladle build && pnpm ladle preview --host 172.17.0.1 --port 40855' \
    'http://172.17.0.1:40855' \
    'docker run --mount type=bind,source="$(realpath .)",target=/usr/app --network host --add-host host.docker.internal:host-gateway playwright-test:latest'
```