### PR TITLE
Allow story-level decorators to respond to theme changes

### DIFF
--- a/.changeset/unlucky-eyes-rescue.md
+++ b/.changeset/unlucky-eyes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Fixes theme change not being registered in story-level decorators

--- a/packages/ladle/lib/app/src/compose-enhancers.tsx
+++ b/packages/ladle/lib/app/src/compose-enhancers.tsx
@@ -39,7 +39,7 @@ export default function composeEnhancers(module: any, storyName: string) {
         ) : (
           <ArgsProvider {...props} />
         ),
-      [globalState.controlInitialized],
+      [globalState.controlInitialized, globalState.theme],
     );
   };
 }


### PR DESCRIPTION
Fixes #386 as it relates to the original issue so that story decorators will respond to pressing the theme toggle button