### PR TITLE
docs: add nextjs clarifications

### DIFF
--- a/packages/website/docs/nextjs.md
+++ b/packages/website/docs/nextjs.md
@@ -7,11 +7,13 @@ title: Next.js
 
 Next.js is a popular React framework that provides a lot of features out of the box. Ladle works well with Next.js, but there are some caveats.
 
-## `next/image`
+## `next/image` and `next/link`
 
 This component relies on a build-time transformation that Next.js provides. However, Ladle has its own build process. To make `next/image` work, we need to replace it with a simple `<img />` element.
 
 ### `vite.config.ts`
+
+You'll probably need to create this file. Place it in the root directory of your project.
 
 ```tsx
 import path from "path";
@@ -21,9 +23,19 @@ export default defineConfig({
   resolve: {
     alias: {
       "next/image": path.resolve(__dirname, "./.ladle/UnoptimizedImage.tsx"),
+      "next/link": path.resolve(__dirname, "./.ladle/UnoptimizedLink.tsx"),
     },
   },
 });
+```
+
+### `.ladle/UnoptimizedLink.tsx`
+
+```tsx
+const UnoptimizedLink = (props: any) => {
+  return <a {...props} />;
+};
+export default UnoptimizedLink;
 ```
 
 ### `.ladle/UnoptimizedImage.tsx`


### PR DESCRIPTION
Same as `next/image`, `next/link` needs to be replaced by a simple `<a {...props} />` tag.

It is probably the same for a lot of other next-specific components.