### PR TITLE
Split NoStories and StoryNotFound components, improve wording, add Back to home link, fix typo in GitHub name

### DIFF
--- a/.changeset/yellow-oranges-tan.md
+++ b/.changeset/yellow-oranges-tan.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": minor
+---
+
+Improved wording on "Story not found" page, added "Back to home" link, fixed typo in GitHub name

--- a/packages/ladle/lib/app/src/no-stories.tsx
+++ b/packages/ladle/lib/app/src/no-stories.tsx
@@ -15,7 +15,7 @@ const NoStories = () => (
       or CLI flag <Code>--stories=your-glob</Code>.
     </p>
     <p>
-      <Link href="https://github.com/tajo/ladle">Github</Link>
+      <Link href="https://github.com/tajo/ladle">GitHub</Link>
     </p>
     <p>
       <Link href="https://www.ladle.dev">Docs</Link>

--- a/packages/ladle/lib/app/src/no-stories.tsx
+++ b/packages/ladle/lib/app/src/no-stories.tsx
@@ -1,38 +1,19 @@
 import { config } from "virtual:generated-list";
 import { Code, Link } from "./ui";
 
-const NoStories = ({
-  wrongUrl,
-  activeStory,
-}: {
-  wrongUrl?: boolean;
-  activeStory?: string;
-}) => (
+const NoStories = () => (
   <div className="ladle-error-content">
-    {wrongUrl ? (
-      <>
-        <h1>The story not found</h1>
-        <p>
-          The story id <Code>{activeStory}</Code> you are trying to open does
-          not exist. Typo?
-        </p>
-      </>
-    ) : (
-      <>
-        <h1>No stories found</h1>
-        <p>
-          The configured glob pattern for stories is:{" "}
-          <Code>{config.stories}</Code>.{" "}
-        </p>
-        <p>
-          It can be changed through the{" "}
-          <Link href="https://www.ladle.dev/docs/config#story-filenames">
-            configuration file
-          </Link>{" "}
-          or CLI flag <Code>--stories=your-glob</Code>.
-        </p>
-      </>
-    )}
+    <h1>No stories found</h1>
+    <p>
+      The configured glob pattern for stories is: <Code>{config.stories}</Code>.
+    </p>
+    <p>
+      It can be changed through the{" "}
+      <Link href="https://www.ladle.dev/docs/config#story-filenames">
+        configuration file
+      </Link>{" "}
+      or CLI flag <Code>--stories=your-glob</Code>.
+    </p>
     <p>
       <Link href="https://github.com/tajo/ladle">Github</Link>
     </p>

--- a/packages/ladle/lib/app/src/story-not-found.tsx
+++ b/packages/ladle/lib/app/src/story-not-found.tsx
@@ -2,13 +2,16 @@ import { Code, Link } from "./ui";
 
 const StoryNotFound = ({ activeStory }: { activeStory: string }) => (
   <div className="ladle-error-content">
-    <h1>The story not found</h1>
+    <h1>Story not found</h1>
     <p>
       The story id <Code>{activeStory}</Code> you are trying to open does not
       exist. Typo?
     </p>
     <p>
-      <Link href="https://github.com/tajo/ladle">Github</Link>
+      <Link href="/">Back to home</Link>
+    </p>
+    <p>
+      <Link href="https://github.com/tajo/ladle">GitHub</Link>
     </p>
     <p>
       <Link href="https://www.ladle.dev">Docs</Link>

--- a/packages/ladle/lib/app/src/story-not-found.tsx
+++ b/packages/ladle/lib/app/src/story-not-found.tsx
@@ -1,0 +1,19 @@
+import { Code, Link } from "./ui";
+
+const StoryNotFound = ({ activeStory }: { activeStory: string }) => (
+  <div className="ladle-error-content">
+    <h1>The story not found</h1>
+    <p>
+      The story id <Code>{activeStory}</Code> you are trying to open does not
+      exist. Typo?
+    </p>
+    <p>
+      <Link href="https://github.com/tajo/ladle">Github</Link>
+    </p>
+    <p>
+      <Link href="https://www.ladle.dev">Docs</Link>
+    </p>
+  </div>
+);
+
+export default StoryNotFound;

--- a/packages/ladle/lib/app/src/story.tsx
+++ b/packages/ladle/lib/app/src/story.tsx
@@ -7,7 +7,7 @@ import { Ring } from "./icons";
 import type { GlobalState, GlobalAction } from "../../shared/types";
 import { ActionType } from "../../shared/types";
 import config from "./get-config";
-import NoStories from "./no-stories";
+import StoryNotFound from "./story-not-found";
 import { ModeState, ThemeState } from "../../shared/types";
 import { CodeHighlight } from "./addons/source";
 
@@ -181,7 +181,7 @@ const Story = ({
                 {storyData ? (
                   React.createElement(storyData.component)
                 ) : (
-                  <NoStories wrongUrl activeStory={globalState.story} />
+                  <StoryNotFound activeStory={globalState.story} />
                 )}
               </Provider>
             </MDXProvider>


### PR DESCRIPTION
NoStories component served two purposes, and these purposes had little in common. Furthermore, it was not fully type safe as all props were optional. Splitting these components make them easier to work with.

I added Back to home link so that if you are in full screen mode without navigation you still have an easy escape hatch.

I fixed GitHub name which had a typo in it.