### PR TITLE
Pin vite-tsconfig-path to 3.6

### DIFF
--- a/e2e/config-ts/src/paths.show.tsx
+++ b/e2e/config-ts/src/paths.show.tsx
@@ -1,0 +1,3 @@
+import { label } from "@/label";
+
+export const Path = () => <h1>{label}</h1>;

--- a/e2e/config-ts/src/to/label.ts
+++ b/e2e/config-ts/src/to/label.ts
@@ -1,0 +1,1 @@
+export const label = "label";

--- a/e2e/config-ts/tests/paths.spec.ts
+++ b/e2e/config-ts/tests/paths.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "@playwright/test";
+
+test("vite-tsconfig-path works", async ({ page }) => {
+  await page.goto("/?story=paths--path");
+  await expect(page.locator("h1")).toHaveText("label");
+});

--- a/e2e/config-ts/tsconfig.json
+++ b/e2e/config-ts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["**/*", "./src/**/*"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/to/*"]
+    }
+  }
+}

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -69,7 +69,7 @@
     "source-map": "^0.7.4",
     "vfile": "^5.3.7",
     "vite": "4.2.1",
-    "vite-tsconfig-paths": "^4.0.8"
+    "vite-tsconfig-paths": "3.6.0"
   },
   "peerDependencies": {
     "react": ">=16.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,8 +437,8 @@ importers:
         specifier: 4.2.1
         version: 4.2.1(@types/node@18.15.11)
       vite-tsconfig-paths:
-        specifier: ^4.0.8
-        version: 4.0.8(typescript@5.0.3)(vite@4.2.1)
+        specifier: 3.6.0
+        version: 3.6.0(vite@4.2.1)
     devDependencies:
       '@babel/cli':
         specifier: ^7.21.0
@@ -2236,7 +2236,7 @@ packages:
     dev: true
 
   /@colors/colors@1.5.0:
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    resolution: {integrity: sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k=, tarball: https://unpm.uberinternal.com/%40colors%2Fcolors/-/colors-1.5.0.tgz}
     engines: {node: '>=0.1.90'}
     requiresBuild: true
     dev: false
@@ -2415,6 +2415,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  /@cush/relative@1.0.0:
+    resolution: {integrity: sha1-jNF2m/m947sn2sNWsbyUr0D2zBY=, tarball: https://unpm.uberinternal.com/%40cush%2Frelative/-/relative-1.0.0.tgz}
+    dev: false
 
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -3033,7 +3037,7 @@ packages:
     dev: false
 
   /@docusaurus/react-loadable@5.5.2(react@17.0.2):
-    resolution: {integrity: sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==}
+    resolution: {integrity: sha1-garg24Hsr72u42UfEoBFgIaPps4=, tarball: https://unpm.uberinternal.com/%40docusaurus%2Freact-loadable/-/react-loadable-5.5.2.tgz}
     peerDependencies:
       react: '*'
     dependencies:
@@ -3316,7 +3320,7 @@ packages:
     dev: false
 
   /@esbuild/android-arm64@0.17.16:
-    resolution: {integrity: sha512-QX48qmsEZW+gcHgTmAj+x21mwTz8MlYQBnzF6861cNdQGvj2jzzFjqH0EBabrIa/WVZ2CHolwMoqxVryqKt8+Q==}
+    resolution: {integrity: sha1-exjKtfTZPoeDBhlu7Sa22WDBJXY=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fandroid-arm64/-/android-arm64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -3324,7 +3328,7 @@ packages:
     optional: true
 
   /@esbuild/android-arm@0.17.16:
-    resolution: {integrity: sha512-baLqRpLe4JnKrUXLJChoTN0iXZH7El/mu58GE3WIA6/H834k0XWvLRmGLG8y8arTRS9hJJibPnF0tiGhmWeZgw==}
+    resolution: {integrity: sha1-XEf2p8LK2m7UtNTnLYxm522BKBI=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fandroid-arm/-/android-arm-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -3332,7 +3336,7 @@ packages:
     optional: true
 
   /@esbuild/android-x64@0.17.16:
-    resolution: {integrity: sha512-G4wfHhrrz99XJgHnzFvB4UwwPxAWZaZBOFXh+JH1Duf1I4vIVfuYY9uVLpx4eiV2D/Jix8LJY+TAdZ3i40tDow==}
+    resolution: {integrity: sha1-hoam6YNZBx/9UxIEZVGUPnJExRo=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fandroid-x64/-/android-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -3340,7 +3344,7 @@ packages:
     optional: true
 
   /@esbuild/darwin-arm64@0.17.16:
-    resolution: {integrity: sha512-/Ofw8UXZxuzTLsNFmz1+lmarQI6ztMZ9XktvXedTbt3SNWDn0+ODTwxExLYQ/Hod91EZB4vZPQJLoqLF0jvEzA==}
+    resolution: {integrity: sha1-qnn79EdjDKBpallr66lip3W785Q=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fdarwin-arm64/-/darwin-arm64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -3348,7 +3352,7 @@ packages:
     optional: true
 
   /@esbuild/darwin-x64@0.17.16:
-    resolution: {integrity: sha512-SzBQtCV3Pdc9kyizh36Ol+dNVhkDyIrGb/JXZqFq8WL37LIyrXU0gUpADcNV311sCOhvY+f2ivMhb5Tuv8nMOQ==}
+    resolution: {integrity: sha1-1daO5RBQcQTafnUDIkxkfJV+Fj4=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fdarwin-x64/-/darwin-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -3356,7 +3360,7 @@ packages:
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.16:
-    resolution: {integrity: sha512-ZqftdfS1UlLiH1DnS2u3It7l4Bc3AskKeu+paJSfk7RNOMrOxmeFDhLTMQqMxycP1C3oj8vgkAT6xfAuq7ZPRA==}
+    resolution: {integrity: sha1-sAtMyMLkJJB8/jpgc4SrJHlO3VI=, tarball: https://unpm.uberinternal.com/%40esbuild%2Ffreebsd-arm64/-/freebsd-arm64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -3364,7 +3368,7 @@ packages:
     optional: true
 
   /@esbuild/freebsd-x64@0.17.16:
-    resolution: {integrity: sha512-rHV6zNWW1tjgsu0dKQTX9L0ByiJHHLvQKrWtnz8r0YYJI27FU3Xu48gpK2IBj1uCSYhJ+pEk6Y0Um7U3rIvV8g==}
+    resolution: {integrity: sha1-hK9EMKB3MLULvJRakM9wNsGFO3Y=, tarball: https://unpm.uberinternal.com/%40esbuild%2Ffreebsd-x64/-/freebsd-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -3372,7 +3376,7 @@ packages:
     optional: true
 
   /@esbuild/linux-arm64@0.17.16:
-    resolution: {integrity: sha512-8yoZhGkU6aHu38WpaM4HrRLTFc7/VVD9Q2SvPcmIQIipQt2I/GMTZNdEHXoypbbGao5kggLcxg0iBKjo0SQYKA==}
+    resolution: {integrity: sha1-NVcdFd5icshi2c5jQTcvs87w8mY=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-arm64/-/linux-arm64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -3380,7 +3384,7 @@ packages:
     optional: true
 
   /@esbuild/linux-arm@0.17.16:
-    resolution: {integrity: sha512-n4O8oVxbn7nl4+m+ISb0a68/lcJClIbaGAoXwqeubj/D1/oMMuaAXmJVfFlRjJLu/ZvHkxoiFJnmbfp4n8cdSw==}
+    resolution: {integrity: sha1-tlx81bDq3Qj5Gqtmud2oG2pLKnA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-arm/-/linux-arm-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3388,7 +3392,7 @@ packages:
     optional: true
 
   /@esbuild/linux-ia32@0.17.16:
-    resolution: {integrity: sha512-9ZBjlkdaVYxPNO8a7OmzDbOH9FMQ1a58j7Xb21UfRU29KcEEU3VTHk+Cvrft/BNv0gpWJMiiZ/f4w0TqSP0gLA==}
+    resolution: {integrity: sha1-ZzpoyyUc5EoApkIq2ikGTFoc0sA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-ia32/-/linux-ia32-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -3396,7 +3400,7 @@ packages:
     optional: true
 
   /@esbuild/linux-loong64@0.17.16:
-    resolution: {integrity: sha512-TIZTRojVBBzdgChY3UOG7BlPhqJz08AL7jdgeeu+kiObWMFzGnQD7BgBBkWRwOtKR1i2TNlO7YK6m4zxVjjPRQ==}
+    resolution: {integrity: sha1-R34to0q0b/2/R0D6ZEHoAEUkk4U=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-loong64/-/linux-loong64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -3404,7 +3408,7 @@ packages:
     optional: true
 
   /@esbuild/linux-mips64el@0.17.16:
-    resolution: {integrity: sha512-UPeRuFKCCJYpBbIdczKyHLAIU31GEm0dZl1eMrdYeXDH+SJZh/i+2cAmD3A1Wip9pIc5Sc6Kc5cFUrPXtR0XHA==}
+    resolution: {integrity: sha1-4eloe72qgx18NO3JJ4IAmCwaS/Q=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-mips64el/-/linux-mips64el-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -3412,7 +3416,7 @@ packages:
     optional: true
 
   /@esbuild/linux-ppc64@0.17.16:
-    resolution: {integrity: sha512-io6yShgIEgVUhExJejJ21xvO5QtrbiSeI7vYUnr7l+v/O9t6IowyhdiYnyivX2X5ysOVHAuyHW+Wyi7DNhdw6Q==}
+    resolution: {integrity: sha1-LxkHXWNiKYfoboOkt4Zs1Xt5bGA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-ppc64/-/linux-ppc64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -3420,7 +3424,7 @@ packages:
     optional: true
 
   /@esbuild/linux-riscv64@0.17.16:
-    resolution: {integrity: sha512-WhlGeAHNbSdG/I2gqX2RK2gfgSNwyJuCiFHMc8s3GNEMMHUI109+VMBfhVqRb0ZGzEeRiibi8dItR3ws3Lk+cA==}
+    resolution: {integrity: sha1-u/QKOPA7okNP5ptc7uxdE8dCsyk=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-riscv64/-/linux-riscv64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -3428,7 +3432,7 @@ packages:
     optional: true
 
   /@esbuild/linux-s390x@0.17.16:
-    resolution: {integrity: sha512-gHRReYsJtViir63bXKoFaQ4pgTyah4ruiMRQ6im9YZuv+gp3UFJkNTY4sFA73YDynmXZA6hi45en4BGhNOJUsw==}
+    resolution: {integrity: sha1-0rjAd5zNK3kXzfD6uIMaRo4PnAE=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-s390x/-/linux-s390x-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -3436,7 +3440,7 @@ packages:
     optional: true
 
   /@esbuild/linux-x64@0.17.16:
-    resolution: {integrity: sha512-mfiiBkxEbUHvi+v0P+TS7UnA9TeGXR48aK4XHkTj0ZwOijxexgMF01UDFaBX7Q6CQsB0d+MFNv9IiXbIHTNd4g==}
+    resolution: {integrity: sha1-2kiznP3BsSp0l2Yl9YPwMerENZA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-x64/-/linux-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -3444,7 +3448,7 @@ packages:
     optional: true
 
   /@esbuild/netbsd-x64@0.17.16:
-    resolution: {integrity: sha512-n8zK1YRDGLRZfVcswcDMDM0j2xKYLNXqei217a4GyBxHIuPMGrrVuJ+Ijfpr0Kufcm7C1k/qaIrGy6eG7wvgmA==}
+    resolution: {integrity: sha1-3e+YWu03zIGQjSVztmwCmdvEkDc=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fnetbsd-x64/-/netbsd-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -3452,7 +3456,7 @@ packages:
     optional: true
 
   /@esbuild/openbsd-x64@0.17.16:
-    resolution: {integrity: sha512-lEEfkfsUbo0xC47eSTBqsItXDSzwzwhKUSsVaVjVji07t8+6KA5INp2rN890dHZeueXJAI8q0tEIfbwVRYf6Ew==}
+    resolution: {integrity: sha1-hQNb+J79ZukGi8cqpruFosMX0JA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fopenbsd-x64/-/openbsd-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -3460,7 +3464,7 @@ packages:
     optional: true
 
   /@esbuild/sunos-x64@0.17.16:
-    resolution: {integrity: sha512-jlRjsuvG1fgGwnE8Afs7xYDnGz0dBgTNZfgCK6TlvPH3Z13/P5pi6I57vyLE8qZYLrGVtwcm9UbUx1/mZ8Ukag==}
+    resolution: {integrity: sha1-FjOOyrhUyy2DHMnunMIe9pVm4fM=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fsunos-x64/-/sunos-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -3468,7 +3472,7 @@ packages:
     optional: true
 
   /@esbuild/win32-arm64@0.17.16:
-    resolution: {integrity: sha512-TzoU2qwVe2boOHl/3KNBUv2PNUc38U0TNnzqOAcgPiD/EZxT2s736xfC2dYQbszAwo4MKzzwBV0iHjhfjxMimg==}
+    resolution: {integrity: sha1-Qj9Gu3RK/4l6X3RDVGnh70lS40M=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fwin32-arm64/-/win32-arm64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3476,7 +3480,7 @@ packages:
     optional: true
 
   /@esbuild/win32-ia32@0.17.16:
-    resolution: {integrity: sha512-B8b7W+oo2yb/3xmwk9Vc99hC9bNolvqjaTZYEfMQhzdpBsjTvZBlXQ/teUE55Ww6sg//wlcDjOaqldOKyigWdA==}
+    resolution: {integrity: sha1-GXi+WxkscGO9LI1ZYOshPhlkdA4=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fwin32-ia32/-/win32-ia32-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -3484,7 +3488,7 @@ packages:
     optional: true
 
   /@esbuild/win32-x64@0.17.16:
-    resolution: {integrity: sha512-xJ7OH/nanouJO9pf03YsL9NAFQBHd8AqfrQd7Pf5laGyyTt/gToul6QYOA/i5i/q8y9iaM5DQFNTgpi995VkOg==}
+    resolution: {integrity: sha1-Jg8ZsKMwDSLDo/UnIsZx3FYe2qM=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fwin32-x64/-/win32-x64-0.17.16.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3722,7 +3726,7 @@ packages:
     dev: false
 
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
-    resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
+    resolution: {integrity: sha1-Mj1y3SUQPQxPvc6J2t9XSnh7H5s=, tarball: https://unpm.uberinternal.com/%40nicolo-ribaudo%2Fchokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz}
     requiresBuild: true
     dev: true
     optional: true
@@ -3946,7 +3950,7 @@ packages:
     dev: false
 
   /@swc/core-darwin-arm64@1.3.49:
-    resolution: {integrity: sha512-g7aIfXh6uPHmhLXdjXQq5t3HAyS/EdvujasW1DIS5k8UqOBaSoCcSGtLIjzcLv3KujqNfYcm118E+12H0nY6fQ==}
+    resolution: {integrity: sha1-vFLFyv9uDqBPXtRXzNeQQShjJSQ=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-darwin-arm64/-/core-darwin-arm64-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -3955,7 +3959,7 @@ packages:
     optional: true
 
   /@swc/core-darwin-x64@1.3.49:
-    resolution: {integrity: sha512-eSIxVX0YDw40Bre5sAx2BV3DzdIGzmQvCf2yiBvLqiiL6GC0mmuDeWbUCAzdUX6fJ6FUVEBMUVqNOc9oJ2/d5w==}
+    resolution: {integrity: sha1-0dqFRAOAvfYrPPJzrSm+VXXNAtY=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-darwin-x64/-/core-darwin-x64-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -3964,7 +3968,7 @@ packages:
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.3.49:
-    resolution: {integrity: sha512-8mj3IcRVr/OJY0mVITz6Z5osNAMJK5GiKDaZ+3QejPLbl6aiu4sH4GmTHDRN14RnaVXOpecsGcUoQmNoNa3u3w==}
+    resolution: {integrity: sha1-0ZMIngIhHcehG/8KYO8Jj3xIeiY=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -3973,43 +3977,47 @@ packages:
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.3.49:
-    resolution: {integrity: sha512-Rmg9xw6tmpOpf6GKKjpHQGmjfHzqSths5ebI2ahrHlhekzZF2HYmPkVw4bHda8Bja6mbaw8FVBgBHjPU8mMeDA==}
+    resolution: {integrity: sha1-xFECqTuNfmdhfy1IhUmtjSuyb3M=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
 
   /@swc/core-linux-arm64-musl@1.3.49:
-    resolution: {integrity: sha512-nlKPYMogAI3Aak6Mlkag8/2AlHAZ/DpH7RjhfMazsaGhD/sQOmYdyY9Al69ejpa419YJuREeeeLoojFlSsd30g==}
+    resolution: {integrity: sha1-OR8g/4O3GVoqFgHmzbGR4bT8ES0=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-arm64-musl/-/core-linux-arm64-musl-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
 
   /@swc/core-linux-x64-gnu@1.3.49:
-    resolution: {integrity: sha512-QOyeJQ6NVi73SJcizbwvIZTiGA/N+BxX9liRrvibumaQmRh8fWjJiLNsv3ODSHeuonak7E8Bf7a7NnSTyu48Mw==}
+    resolution: {integrity: sha1-NsehZaC7t2Pq9xhu69dZcxywWNI=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-x64-gnu/-/core-linux-x64-gnu-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
 
   /@swc/core-linux-x64-musl@1.3.49:
-    resolution: {integrity: sha512-WlDMz+SOpYC9O/ZBUw1oiyWI7HyUCMlf/HS8Fy/kRI3eGoGCUxVTCJ1mP57GdQr4Wg32Y/ZpO2KSNQFWnT8mAw==}
+    resolution: {integrity: sha1-a5+FtF8Raq+Qntnuj+LRnhn8qPs=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-x64-musl/-/core-linux-x64-musl-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.3.49:
-    resolution: {integrity: sha512-41LZOeI94Za3twib8KOIjnHYAZ+nkBFmboaREsFR1760S7jiMVywqWX8nFZvn/CXj15Fjjgdgyuig+zMREwXwQ==}
+    resolution: {integrity: sha1-91xpz1gEVDt0hGslHew3KUZtaRo=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -4018,7 +4026,7 @@ packages:
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.3.49:
-    resolution: {integrity: sha512-IdqLPoMKssyAoOCZdNXmnAd6/uyx+Hb9KSfZUHepZaNfwMy6J5XXrOsbYs3v53FH8MtekUUdV+mMX4me9bcv9w==}
+    resolution: {integrity: sha1-j+oXHvX9xpgxdFYPD3KjD22gtro=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -4027,7 +4035,7 @@ packages:
     optional: true
 
   /@swc/core-win32-x64-msvc@1.3.49:
-    resolution: {integrity: sha512-7Fqjo5pS3uIohhSbYSaR0+e/bJdxmQb4oG97FIh5qvlCCGQaQ9UiaEeYy4uK0Ad+Menum1IXCAEiG7RHcl6Eyw==}
+    resolution: {integrity: sha1-5aSjNwu1Wqw24Z1h70Ovbc/nbAk=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-win32-x64-msvc/-/core-win32-x64-msvc-1.3.49.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -6298,7 +6306,7 @@ packages:
     dev: true
 
   /debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    resolution: {integrity: sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -7523,7 +7531,7 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -7632,6 +7640,10 @@ packages:
     dependencies:
       is-glob: 4.0.3
 
+  /glob-regex@0.3.2:
+    resolution: {integrity: sha1-JzSPL2BkjsMqSlMTcJC5+5NPNCU=}
+    dev: false
+
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: false
@@ -7727,7 +7739,7 @@ packages:
     dev: false
 
   /globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    resolution: {integrity: sha1-3V2eyCYjJzDNZ5Ol4zqTApheYJg=}
     dev: false
 
   /gopd@1.0.1:
@@ -11536,6 +11548,16 @@ packages:
       resolve: 1.22.2
     dev: false
 
+  /recrawl-sync@2.2.3:
+    resolution: {integrity: sha1-dXrc2q5HmUZt3luO5SEi/5Y237E=}
+    dependencies:
+      '@cush/relative': 1.0.0
+      glob-regex: 0.3.2
+      slash: 3.0.0
+      sucrase: 3.32.0
+      tslib: 1.14.1
+    dev: false
+
   /recursive-readdir@2.2.3:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
@@ -12192,7 +12214,7 @@ packages:
     dev: true
 
   /slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    resolution: {integrity: sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=}
     engines: {node: '>=8'}
 
   /slash@4.0.0:
@@ -12498,7 +12520,6 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-    dev: true
 
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -12879,22 +12900,17 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@2.1.1(typescript@5.0.3):
-    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
-    engines: {node: ^14.13.1 || ^16 || >=18}
-    hasBin: true
-    peerDependencies:
-      typescript: ^4.3.5 || ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  /tsconfig-paths@4.2.0:
+    resolution: {integrity: sha1-73jhkDkTNEbSRL6sD9ahYy4tEHw=}
+    engines: {node: '>=6'}
     dependencies:
-      typescript: 5.0.3
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
     dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: true
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -12936,7 +12952,7 @@ packages:
     dev: false
 
   /turbo-darwin-64@1.9.1:
-    resolution: {integrity: sha512-IX/Ph4CO80lFKd9pPx3BWpN2dynt6mcUFifyuHUNVkOP1Usza/G9YuZnKQFG6wUwKJbx40morFLjk1TTeLe04w==}
+    resolution: {integrity: sha1-HwTnFq1s8HGCLwwaSZ9PzXvUD0s=}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -12944,7 +12960,7 @@ packages:
     optional: true
 
   /turbo-darwin-arm64@1.9.1:
-    resolution: {integrity: sha512-6tCbmIboy9dTbhIZ/x9KIpje73nvxbiyVnHbr9xKnsxLJavD0xqjHZzbL5U2tHp8chqmYf0E4WYOXd+XCNg+OQ==}
+    resolution: {integrity: sha1-GewWGFj7Jt+9Up4OydbJtEhOkbA=}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -12952,7 +12968,7 @@ packages:
     optional: true
 
   /turbo-linux-64@1.9.1:
-    resolution: {integrity: sha512-ti8XofnJFO1XaadL92lYJXgxb0VBl03Yu9VfhxkOTywFe7USTLBkJcdvQ4EpFk/KZwLiTdCmT2NQVxsG4AxBiQ==}
+    resolution: {integrity: sha1-W0fg8JEvcJqaLjJf6qfiYKp2z0k=}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -12960,7 +12976,7 @@ packages:
     optional: true
 
   /turbo-linux-arm64@1.9.1:
-    resolution: {integrity: sha512-XYvIbeiCCCr+ENujd2Jtck/lJPTKWb8T2MSL/AEBx21Zy3Sa7HgrQX6LX0a0pNHjaleHz00XXt1D0W5hLeP+tA==}
+    resolution: {integrity: sha1-2wNQYXYOhRKkCKZMwtfVaPUQKrc=}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -12968,7 +12984,7 @@ packages:
     optional: true
 
   /turbo-windows-64@1.9.1:
-    resolution: {integrity: sha512-x7lWAspe4/v3XQ0gaFRWDX/X9uyWdhwFBPEfb8BA0YKtnsrPOHkV0mRHCRrXzvzjA7pcDCl2agGzb7o863O+Jg==}
+    resolution: {integrity: sha1-Vq2Y5HAbRSPxGDl9mNZOvvXauI8=}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -12976,7 +12992,7 @@ packages:
     optional: true
 
   /turbo-windows-arm64@1.9.1:
-    resolution: {integrity: sha512-QSLNz8dRBLDqXOUv/KnoesBomSbIz2Huef/a3l2+Pat5wkQVgMfzFxDOnkK5VWujPYXz+/prYz+/7cdaC78/kw==}
+    resolution: {integrity: sha1-8MeAzJBt7f+F7vIPBj9ZqbKoZfw=}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -13489,21 +13505,18 @@ packages:
       - terser
     dev: true
 
-  /vite-tsconfig-paths@4.0.8(typescript@5.0.3)(vite@4.2.1):
-    resolution: {integrity: sha512-p04zH+Ey+NT78571x0pdX7nVRIJSlmKVvYryFglSWOK3Hc72eDL0+JJfbyQiugaIBApJkaEqbBQvqpsFZOSVGg==}
+  /vite-tsconfig-paths@3.6.0(vite@4.2.1):
+    resolution: {integrity: sha1-nmNjBRssqvfHzsb5+FrXH+7neSA=}
     peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
+      vite: '>2.0.0-0'
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@5.0.3)
+      recrawl-sync: 2.2.3
+      tsconfig-paths: 4.2.0
       vite: 4.2.1(@types/node@18.15.11)
     transitivePeerDependencies:
       - supports-color
-      - typescript
     dev: false
 
   /vite@4.2.1(@types/node@18.15.11):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1931,7 +1931,7 @@ packages:
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.4)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.4)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.4)
-      core-js-compat: 3.30.0
+      core-js-compat: 3.30.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -1989,7 +1989,7 @@ packages:
     resolution: {integrity: sha512-TDD4UJzos3JJtM+tHX+w2Uc+KWj7GV+VKKFdMVd2Rx8sdA19hcc3P3AHFYd5LVOw+pYuSd5lICC3gm52B6Rwxw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      core-js-pure: 3.30.0
+      core-js-pure: 3.30.1
       regenerator-runtime: 0.13.11
     dev: false
 
@@ -2236,7 +2236,7 @@ packages:
     dev: true
 
   /@colors/colors@1.5.0:
-    resolution: {integrity: sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k=, tarball: https://unpm.uberinternal.com/%40colors%2Fcolors/-/colors-1.5.0.tgz}
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
     requiresBuild: true
     dev: false
@@ -2248,7 +2248,7 @@ packages:
     hasBin: true
     dependencies:
       '@commitlint/format': 17.4.4
-      '@commitlint/lint': 17.4.4
+      '@commitlint/lint': 17.6.1
       '@commitlint/load': 17.5.0
       '@commitlint/read': 17.5.1
       '@commitlint/types': 17.4.4
@@ -2310,13 +2310,13 @@ packages:
       semver: 7.3.8
     dev: true
 
-  /@commitlint/lint@17.4.4:
-    resolution: {integrity: sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==}
+  /@commitlint/lint@17.6.1:
+    resolution: {integrity: sha512-VARJ9kxH64isgwVnC+ABPafCYzqxpsWJIpDaTuI0gh8aX4GQ0i7cn9tvxtFNfJj4ER2BAJeWJ0vURdNYjK2RQQ==}
     engines: {node: '>=v14'}
     dependencies:
       '@commitlint/is-ignored': 17.4.4
       '@commitlint/parse': 17.4.4
-      '@commitlint/rules': 17.4.4
+      '@commitlint/rules': 17.6.1
       '@commitlint/types': 17.4.4
     dev: true
 
@@ -2380,8 +2380,8 @@ packages:
       resolve-global: 1.0.0
     dev: true
 
-  /@commitlint/rules@17.4.4:
-    resolution: {integrity: sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==}
+  /@commitlint/rules@17.6.1:
+    resolution: {integrity: sha512-lUdHw6lYQ1RywExXDdLOKxhpp6857/4c95Dc/1BikrHgdysVUXz26yV0vp1GL7Gv+avx9WqZWTIVB7pNouxlfw==}
     engines: {node: '>=v14'}
     dependencies:
       '@commitlint/ensure': 17.4.4
@@ -2417,7 +2417,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
 
   /@cush/relative@1.0.0:
-    resolution: {integrity: sha1-jNF2m/m947sn2sNWsbyUr0D2zBY=, tarball: https://unpm.uberinternal.com/%40cush%2Frelative/-/relative-1.0.0.tgz}
+    resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:
@@ -2492,7 +2492,7 @@ packages:
       combine-promises: 1.1.0
       commander: 5.1.0
       copy-webpack-plugin: 11.0.0(webpack@5.79.0)
-      core-js: 3.30.0
+      core-js: 3.30.1
       css-loader: 6.7.3(webpack@5.79.0)
       css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.2)(webpack@5.79.0)
       cssnano: 5.1.15(postcss@8.4.21)
@@ -2504,7 +2504,7 @@ packages:
       fs-extra: 10.1.0
       html-minifier-terser: 6.1.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.5.0(webpack@5.79.0)
+      html-webpack-plugin: 5.5.1(webpack@5.79.0)
       import-fresh: 3.3.0
       leven: 3.1.0
       lodash: 4.17.21
@@ -2522,7 +2522,7 @@ packages:
       react-router-config: 5.1.1(react-router@5.3.4)(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       rtl-detect: 1.0.4
-      semver: 7.4.0
+      semver: 7.5.0
       serve-handler: 6.1.5
       shelljs: 0.8.5
       terser-webpack-plugin: 5.3.7(webpack@5.79.0)
@@ -2532,7 +2532,7 @@ packages:
       wait-on: 6.0.1
       webpack: 5.79.0
       webpack-bundle-analyzer: 4.8.0
-      webpack-dev-server: 4.13.2(webpack@5.79.0)
+      webpack-dev-server: 4.13.3(webpack@5.79.0)
       webpack-merge: 5.8.0
       webpackbar: 5.0.2(webpack@5.79.0)
     transitivePeerDependencies:
@@ -3037,7 +3037,7 @@ packages:
     dev: false
 
   /@docusaurus/react-loadable@5.5.2(react@17.0.2):
-    resolution: {integrity: sha1-garg24Hsr72u42UfEoBFgIaPps4=, tarball: https://unpm.uberinternal.com/%40docusaurus%2Freact-loadable/-/react-loadable-5.5.2.tgz}
+    resolution: {integrity: sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==}
     peerDependencies:
       react: '*'
     dependencies:
@@ -3319,176 +3319,176 @@ packages:
       react-waypoint: 10.3.0(react@17.0.2)
     dev: false
 
-  /@esbuild/android-arm64@0.17.16:
-    resolution: {integrity: sha1-exjKtfTZPoeDBhlu7Sa22WDBJXY=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fandroid-arm64/-/android-arm64-0.17.16.tgz}
+  /@esbuild/android-arm64@0.17.17:
+    resolution: {integrity: sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm@0.17.16:
-    resolution: {integrity: sha1-XEf2p8LK2m7UtNTnLYxm522BKBI=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fandroid-arm/-/android-arm-0.17.16.tgz}
+  /@esbuild/android-arm@0.17.17:
+    resolution: {integrity: sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-x64@0.17.16:
-    resolution: {integrity: sha1-hoam6YNZBx/9UxIEZVGUPnJExRo=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fandroid-x64/-/android-x64-0.17.16.tgz}
+  /@esbuild/android-x64@0.17.17:
+    resolution: {integrity: sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.16:
-    resolution: {integrity: sha1-qnn79EdjDKBpallr66lip3W785Q=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fdarwin-arm64/-/darwin-arm64-0.17.16.tgz}
+  /@esbuild/darwin-arm64@0.17.17:
+    resolution: {integrity: sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.16:
-    resolution: {integrity: sha1-1daO5RBQcQTafnUDIkxkfJV+Fj4=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fdarwin-x64/-/darwin-x64-0.17.16.tgz}
+  /@esbuild/darwin-x64@0.17.17:
+    resolution: {integrity: sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.16:
-    resolution: {integrity: sha1-sAtMyMLkJJB8/jpgc4SrJHlO3VI=, tarball: https://unpm.uberinternal.com/%40esbuild%2Ffreebsd-arm64/-/freebsd-arm64-0.17.16.tgz}
+  /@esbuild/freebsd-arm64@0.17.17:
+    resolution: {integrity: sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.16:
-    resolution: {integrity: sha1-hK9EMKB3MLULvJRakM9wNsGFO3Y=, tarball: https://unpm.uberinternal.com/%40esbuild%2Ffreebsd-x64/-/freebsd-x64-0.17.16.tgz}
+  /@esbuild/freebsd-x64@0.17.17:
+    resolution: {integrity: sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.16:
-    resolution: {integrity: sha1-NVcdFd5icshi2c5jQTcvs87w8mY=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-arm64/-/linux-arm64-0.17.16.tgz}
+  /@esbuild/linux-arm64@0.17.17:
+    resolution: {integrity: sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.16:
-    resolution: {integrity: sha1-tlx81bDq3Qj5Gqtmud2oG2pLKnA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-arm/-/linux-arm-0.17.16.tgz}
+  /@esbuild/linux-arm@0.17.17:
+    resolution: {integrity: sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.16:
-    resolution: {integrity: sha1-ZzpoyyUc5EoApkIq2ikGTFoc0sA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-ia32/-/linux-ia32-0.17.16.tgz}
+  /@esbuild/linux-ia32@0.17.17:
+    resolution: {integrity: sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.16:
-    resolution: {integrity: sha1-R34to0q0b/2/R0D6ZEHoAEUkk4U=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-loong64/-/linux-loong64-0.17.16.tgz}
+  /@esbuild/linux-loong64@0.17.17:
+    resolution: {integrity: sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.16:
-    resolution: {integrity: sha1-4eloe72qgx18NO3JJ4IAmCwaS/Q=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-mips64el/-/linux-mips64el-0.17.16.tgz}
+  /@esbuild/linux-mips64el@0.17.17:
+    resolution: {integrity: sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.16:
-    resolution: {integrity: sha1-LxkHXWNiKYfoboOkt4Zs1Xt5bGA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-ppc64/-/linux-ppc64-0.17.16.tgz}
+  /@esbuild/linux-ppc64@0.17.17:
+    resolution: {integrity: sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.16:
-    resolution: {integrity: sha1-u/QKOPA7okNP5ptc7uxdE8dCsyk=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-riscv64/-/linux-riscv64-0.17.16.tgz}
+  /@esbuild/linux-riscv64@0.17.17:
+    resolution: {integrity: sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.16:
-    resolution: {integrity: sha1-0rjAd5zNK3kXzfD6uIMaRo4PnAE=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-s390x/-/linux-s390x-0.17.16.tgz}
+  /@esbuild/linux-s390x@0.17.17:
+    resolution: {integrity: sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.16:
-    resolution: {integrity: sha1-2kiznP3BsSp0l2Yl9YPwMerENZA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Flinux-x64/-/linux-x64-0.17.16.tgz}
+  /@esbuild/linux-x64@0.17.17:
+    resolution: {integrity: sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.16:
-    resolution: {integrity: sha1-3e+YWu03zIGQjSVztmwCmdvEkDc=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fnetbsd-x64/-/netbsd-x64-0.17.16.tgz}
+  /@esbuild/netbsd-x64@0.17.17:
+    resolution: {integrity: sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.16:
-    resolution: {integrity: sha1-hQNb+J79ZukGi8cqpruFosMX0JA=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fopenbsd-x64/-/openbsd-x64-0.17.16.tgz}
+  /@esbuild/openbsd-x64@0.17.17:
+    resolution: {integrity: sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.16:
-    resolution: {integrity: sha1-FjOOyrhUyy2DHMnunMIe9pVm4fM=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fsunos-x64/-/sunos-x64-0.17.16.tgz}
+  /@esbuild/sunos-x64@0.17.17:
+    resolution: {integrity: sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.16:
-    resolution: {integrity: sha1-Qj9Gu3RK/4l6X3RDVGnh70lS40M=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fwin32-arm64/-/win32-arm64-0.17.16.tgz}
+  /@esbuild/win32-arm64@0.17.17:
+    resolution: {integrity: sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.16:
-    resolution: {integrity: sha1-GXi+WxkscGO9LI1ZYOshPhlkdA4=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fwin32-ia32/-/win32-ia32-0.17.16.tgz}
+  /@esbuild/win32-ia32@0.17.17:
+    resolution: {integrity: sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.16:
-    resolution: {integrity: sha1-Jg8ZsKMwDSLDo/UnIsZx3FYe2qM=, tarball: https://unpm.uberinternal.com/%40esbuild%2Fwin32-x64/-/win32-x64-0.17.16.tgz}
+  /@esbuild/win32-x64@0.17.17:
+    resolution: {integrity: sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3726,7 +3726,7 @@ packages:
     dev: false
 
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
-    resolution: {integrity: sha1-Mj1y3SUQPQxPvc6J2t9XSnh7H5s=, tarball: https://unpm.uberinternal.com/%40nicolo-ribaudo%2Fchokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz}
+    resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
     requiresBuild: true
     dev: true
     optional: true
@@ -3903,7 +3903,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/types': 7.21.4
-      entities: 4.4.0
+      entities: 4.5.0
     dev: false
 
   /@svgr/plugin-jsx@6.5.1(@svgr/core@6.5.1):
@@ -3949,8 +3949,8 @@ packages:
       - supports-color
     dev: false
 
-  /@swc/core-darwin-arm64@1.3.49:
-    resolution: {integrity: sha1-vFLFyv9uDqBPXtRXzNeQQShjJSQ=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-darwin-arm64/-/core-darwin-arm64-1.3.49.tgz}
+  /@swc/core-darwin-arm64@1.3.51:
+    resolution: {integrity: sha512-DM15fJgaXQ+BOoTlMCBoRBSzkpC2V8vAXaAvh3BZ+BI6/03FUQ0j9CMIaSkss3VOv+WwqzllmcT71C/oVDQ7Tg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -3958,8 +3958,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-darwin-x64@1.3.49:
-    resolution: {integrity: sha1-0dqFRAOAvfYrPPJzrSm+VXXNAtY=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-darwin-x64/-/core-darwin-x64-1.3.49.tgz}
+  /@swc/core-darwin-x64@1.3.51:
+    resolution: {integrity: sha512-EPAneufZfFQUkpkf2m8Ap8TajLvjWI+UmDQz54QaofLaigXgrnLoqTtnZHBfDbUTApGYz3GaqjfZ2fMLGiISLQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -3967,8 +3967,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.3.49:
-    resolution: {integrity: sha1-0ZMIngIhHcehG/8KYO8Jj3xIeiY=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.49.tgz}
+  /@swc/core-linux-arm-gnueabihf@1.3.51:
+    resolution: {integrity: sha512-sASxO3lJjlY5g8S25yCQirDOW6zqBNeDSUCBrulaVxttx0PcL64kc6qaOlM3HKlNO4W1P7RW/mGFR4bBov+yIg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -3976,48 +3976,44 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.3.49:
-    resolution: {integrity: sha1-xFECqTuNfmdhfy1IhUmtjSuyb3M=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.49.tgz}
+  /@swc/core-linux-arm64-gnu@1.3.51:
+    resolution: {integrity: sha512-z8yHRUK+5mRxSQkw9uND8QSt8lTrW0X8blmP12Q7c7RKWOHqIaGS60a3VvLuTal7k48K4YTstSevIrGwGK88sA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.3.49:
-    resolution: {integrity: sha1-OR8g/4O3GVoqFgHmzbGR4bT8ES0=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-arm64-musl/-/core-linux-arm64-musl-1.3.49.tgz}
+  /@swc/core-linux-arm64-musl@1.3.51:
+    resolution: {integrity: sha512-lMlp09lv6qDURvETw4AAZAjaJfvjwHjiAuB+JuZrgP3zdxB21M6cMas3EjAGXtNabpU1FJu+8Lsys6/GBBjsPQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.3.49:
-    resolution: {integrity: sha1-NsehZaC7t2Pq9xhu69dZcxywWNI=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-x64-gnu/-/core-linux-x64-gnu-1.3.49.tgz}
+  /@swc/core-linux-x64-gnu@1.3.51:
+    resolution: {integrity: sha512-6zK4tDr6do6RFTJv38Rb8ZjBLdfSN7GeuyOJpblz1Qu62RqyY2Zf3fxuCZY9tkoEepZ0MvU0d4D7HhAUYKj20A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@swc/core-linux-x64-musl@1.3.49:
-    resolution: {integrity: sha1-a5+FtF8Raq+Qntnuj+LRnhn8qPs=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-linux-x64-musl/-/core-linux-x64-musl-1.3.49.tgz}
+  /@swc/core-linux-x64-musl@1.3.51:
+    resolution: {integrity: sha512-ZwW+X9XdEiAszX+zfaLdOVfi5rQP3vnVwuNAiuX9eq5jHdfOKfKaNtJaGTD8w8NgMavaBM5AMaCHshFVNF0vRw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.3.49:
-    resolution: {integrity: sha1-91xpz1gEVDt0hGslHew3KUZtaRo=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.49.tgz}
+  /@swc/core-win32-arm64-msvc@1.3.51:
+    resolution: {integrity: sha512-w+IX4xCIZH6RQG7RrOOrrHqIqM7JIj9BDZHM9LAYC5MIbDinwjnSUXz7bpn0L1LRusvPtmbTulLuSkmVBSSwAg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -4025,8 +4021,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.3.49:
-    resolution: {integrity: sha1-j+oXHvX9xpgxdFYPD3KjD22gtro=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.49.tgz}
+  /@swc/core-win32-ia32-msvc@1.3.51:
+    resolution: {integrity: sha512-Bzv/h0HkoKkTWOOoHtehId/6AS5hLBbWE5czzcQc8SWs+BNNV8zjWoq1oYn7/gLLEhdKaBAxv9q7RHzOfBx28A==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -4034,8 +4030,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.3.49:
-    resolution: {integrity: sha1-5aSjNwu1Wqw24Z1h70Ovbc/nbAk=, tarball: https://unpm.uberinternal.com/%40swc%2Fcore-win32-x64-msvc/-/core-win32-x64-msvc-1.3.49.tgz}
+  /@swc/core-win32-x64-msvc@1.3.51:
+    resolution: {integrity: sha512-dTKAdSd0e2Sfz3Sl3m6RGLQbk6jdSIh8TlFomF4iiHDHq4PxLTzjaOVvKUAP5wux9DtBnAgZeSHMuQfM4aL9oA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -4043,8 +4039,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/core@1.3.49:
-    resolution: {integrity: sha512-br44ZHOfE9YyRGcORSLkHFQHTvhwRcaithBJ1Q5y5iMGpLbH0Wai3GN49L60RvmGwxNJfWzT+E7+rNNR7ewKgA==}
+  /@swc/core@1.3.51:
+    resolution: {integrity: sha512-/fdKlrs2NacLeOKrVZjCPfw5GeUIyBcJg0GDBn0+qwC3Y6k85m4aswK1sfRDF3nzyeXXoBr7YBb+/cSdFq9pVw==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -4053,16 +4049,16 @@ packages:
       '@swc/helpers':
         optional: true
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.49
-      '@swc/core-darwin-x64': 1.3.49
-      '@swc/core-linux-arm-gnueabihf': 1.3.49
-      '@swc/core-linux-arm64-gnu': 1.3.49
-      '@swc/core-linux-arm64-musl': 1.3.49
-      '@swc/core-linux-x64-gnu': 1.3.49
-      '@swc/core-linux-x64-musl': 1.3.49
-      '@swc/core-win32-arm64-msvc': 1.3.49
-      '@swc/core-win32-ia32-msvc': 1.3.49
-      '@swc/core-win32-x64-msvc': 1.3.49
+      '@swc/core-darwin-arm64': 1.3.51
+      '@swc/core-darwin-x64': 1.3.51
+      '@swc/core-linux-arm-gnueabihf': 1.3.51
+      '@swc/core-linux-arm64-gnu': 1.3.51
+      '@swc/core-linux-arm64-musl': 1.3.51
+      '@swc/core-linux-x64-gnu': 1.3.51
+      '@swc/core-linux-x64-musl': 1.3.51
+      '@swc/core-win32-arm64-msvc': 1.3.51
+      '@swc/core-win32-ia32-msvc': 1.3.51
+      '@swc/core-win32-x64-msvc': 1.3.51
     dev: false
 
   /@szmarczak/http-timer@1.1.2:
@@ -4316,11 +4312,11 @@ packages:
   /@types/lodash.merge@4.6.7:
     resolution: {integrity: sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==}
     dependencies:
-      '@types/lodash': 4.14.192
+      '@types/lodash': 4.14.194
     dev: true
 
-  /@types/lodash@4.14.192:
-    resolution: {integrity: sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==}
+  /@types/lodash@4.14.194:
+    resolution: {integrity: sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==}
     dev: true
 
   /@types/mdast@3.0.11:
@@ -4517,7 +4513,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
-      semver: 7.4.0
+      semver: 7.5.0
       tsutils: 3.21.0(typescript@5.0.3)
       typescript: 5.0.3
     transitivePeerDependencies:
@@ -4591,7 +4587,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.4.0
+      semver: 7.5.0
       tsutils: 3.21.0(typescript@5.0.3)
       typescript: 5.0.3
     transitivePeerDependencies:
@@ -4612,7 +4608,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.3)
       eslint: 8.37.0
       eslint-scope: 5.1.1
-      semver: 7.4.0
+      semver: 7.5.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4631,7 +4627,7 @@ packages:
     peerDependencies:
       vite: ^4
     dependencies:
-      '@swc/core': 1.3.49
+      '@swc/core': 1.3.51
       vite: 4.2.1(@types/node@18.15.11)
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -5104,7 +5100,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001478
+      caniuse-lite: 1.0.30001480
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -5218,7 +5214,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.4)
-      core-js-compat: 3.30.0
+      core-js-compat: 3.30.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5394,10 +5390,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001478
-      electron-to-chromium: 1.4.361
+      caniuse-lite: 1.0.30001480
+      electron-to-chromium: 1.4.367
       node-releases: 2.0.10
-      update-browserslist-db: 1.0.10(browserslist@4.21.5)
+      update-browserslist-db: 1.0.11(browserslist@4.21.5)
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -5503,13 +5499,13 @@ packages:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001478
+      caniuse-lite: 1.0.30001480
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
 
-  /caniuse-lite@1.0.30001478:
-    resolution: {integrity: sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==}
+  /caniuse-lite@1.0.30001480:
+    resolution: {integrity: sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==}
 
   /ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -5786,8 +5782,8 @@ packages:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
     dev: false
 
-  /colorette@2.0.19:
-    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+  /colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
     dev: false
 
   /combine-promises@1.1.0:
@@ -5981,24 +5977,24 @@ packages:
       glob-parent: 6.0.2
       globby: 13.1.3
       normalize-path: 3.0.0
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
       serialize-javascript: 6.0.1
       webpack: 5.79.0
     dev: false
 
-  /core-js-compat@3.30.0:
-    resolution: {integrity: sha512-P5A2h/9mRYZFIAP+5Ab8ns6083IyVpSclU74UNvbGVQ8VM7n3n3/g2yF3AkKQ9NXz2O+ioxLbEWKnDtgsFamhg==}
+  /core-js-compat@3.30.1:
+    resolution: {integrity: sha512-d690npR7MC6P0gq4npTl5n2VQeNAmUrJ90n+MHiKS7W2+xno4o3F5GDEuylSdi6EJ3VssibSGXOa1r3YXD3Mhw==}
     dependencies:
       browserslist: 4.21.5
     dev: false
 
-  /core-js-pure@3.30.0:
-    resolution: {integrity: sha512-+2KbMFGeBU0ln/csoPqTe0i/yfHbrd2EUhNMObsGtXMKS/RTtlkYyi+/3twLcevbgNR0yM/r0Psa3TEoQRpFMQ==}
+  /core-js-pure@3.30.1:
+    resolution: {integrity: sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==}
     requiresBuild: true
     dev: false
 
-  /core-js@3.30.0:
-    resolution: {integrity: sha512-hQotSSARoNh1mYPi9O2YaWeiq/cEB95kOrFb4NCrO4RIFt1qqNpKsaE+vy/L3oiqvND5cThqXzUU3r9F7Efztg==}
+  /core-js@3.30.1:
+    resolution: {integrity: sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ==}
     requiresBuild: true
     dev: false
 
@@ -6112,7 +6108,7 @@ packages:
       postcss-modules-scope: 3.0.0(postcss@8.4.21)
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
-      semver: 7.4.0
+      semver: 7.5.0
       webpack: 5.79.0
     dev: false
 
@@ -6145,7 +6141,7 @@ packages:
       cssnano: 5.1.15(postcss@8.4.21)
       jest-worker: 29.5.0
       postcss: 8.4.21
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
       serialize-javascript: 6.0.1
       source-map: 0.6.1
       webpack: 5.79.0
@@ -6306,7 +6302,7 @@ packages:
     dev: true
 
   /debug@2.6.9:
-    resolution: {integrity: sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=}
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -6590,7 +6586,7 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      entities: 4.4.0
+      entities: 4.5.0
     dev: false
 
   /domelementtype@2.3.0:
@@ -6660,8 +6656,8 @@ packages:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
-  /electron-to-chromium@1.4.361:
-    resolution: {integrity: sha512-VocVwjPp05HUXzf3xmL0boRn5b0iyqC7amtDww84Jb1QJNPBc7F69gJyEeXRoriLBC4a5pSyckdllrXAg4mmRA==}
+  /electron-to-chromium@1.4.367:
+    resolution: {integrity: sha512-mNuDxb+HpLhPGUKrg0hSxbTjHWw8EziwkwlJNkFUj3W60ypigLDRVz04vU+VRsJPi8Gub+FDhYUpuTm9xiEwRQ==}
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -6707,8 +6703,8 @@ packages:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
     dev: false
 
-  /entities@4.4.0:
-    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
     dev: false
 
@@ -6785,34 +6781,34 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /esbuild@0.17.16:
-    resolution: {integrity: sha512-aeSuUKr9aFVY9Dc8ETVELGgkj4urg5isYx8pLf4wlGgB0vTFjxJQdHnNH6Shmx4vYYrOTLCHtRI5i1XZ9l2Zcg==}
+  /esbuild@0.17.17:
+    resolution: {integrity: sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.16
-      '@esbuild/android-arm64': 0.17.16
-      '@esbuild/android-x64': 0.17.16
-      '@esbuild/darwin-arm64': 0.17.16
-      '@esbuild/darwin-x64': 0.17.16
-      '@esbuild/freebsd-arm64': 0.17.16
-      '@esbuild/freebsd-x64': 0.17.16
-      '@esbuild/linux-arm': 0.17.16
-      '@esbuild/linux-arm64': 0.17.16
-      '@esbuild/linux-ia32': 0.17.16
-      '@esbuild/linux-loong64': 0.17.16
-      '@esbuild/linux-mips64el': 0.17.16
-      '@esbuild/linux-ppc64': 0.17.16
-      '@esbuild/linux-riscv64': 0.17.16
-      '@esbuild/linux-s390x': 0.17.16
-      '@esbuild/linux-x64': 0.17.16
-      '@esbuild/netbsd-x64': 0.17.16
-      '@esbuild/openbsd-x64': 0.17.16
-      '@esbuild/sunos-x64': 0.17.16
-      '@esbuild/win32-arm64': 0.17.16
-      '@esbuild/win32-ia32': 0.17.16
-      '@esbuild/win32-x64': 0.17.16
+      '@esbuild/android-arm': 0.17.17
+      '@esbuild/android-arm64': 0.17.17
+      '@esbuild/android-x64': 0.17.17
+      '@esbuild/darwin-arm64': 0.17.17
+      '@esbuild/darwin-x64': 0.17.17
+      '@esbuild/freebsd-arm64': 0.17.17
+      '@esbuild/freebsd-x64': 0.17.17
+      '@esbuild/linux-arm': 0.17.17
+      '@esbuild/linux-arm64': 0.17.17
+      '@esbuild/linux-ia32': 0.17.17
+      '@esbuild/linux-loong64': 0.17.17
+      '@esbuild/linux-mips64el': 0.17.17
+      '@esbuild/linux-ppc64': 0.17.17
+      '@esbuild/linux-riscv64': 0.17.17
+      '@esbuild/linux-s390x': 0.17.17
+      '@esbuild/linux-x64': 0.17.17
+      '@esbuild/netbsd-x64': 0.17.17
+      '@esbuild/openbsd-x64': 0.17.17
+      '@esbuild/sunos-x64': 0.17.17
+      '@esbuild/win32-arm64': 0.17.17
+      '@esbuild/win32-ia32': 0.17.17
+      '@esbuild/win32-x64': 0.17.17
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -6897,8 +6893,8 @@ packages:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  /eslint-scope@7.1.1:
-    resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
+  /eslint-scope@7.2.0:
+    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
@@ -6926,7 +6922,7 @@ packages:
       debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
-      eslint-scope: 7.1.1
+      eslint-scope: 7.2.0
       eslint-visitor-keys: 3.4.0
       espree: 9.5.1
       esquery: 1.5.0
@@ -7274,7 +7270,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       webpack: 5.79.0
     dev: false
 
@@ -7427,7 +7423,7 @@ packages:
       memfs: 3.5.0
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.4.0
+      semver: 7.5.0
       tapable: 1.1.3
       typescript: 5.0.3
       webpack: 5.79.0
@@ -7531,7 +7527,7 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   /fsevents@2.3.2:
-    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -7641,7 +7637,7 @@ packages:
       is-glob: 4.0.3
 
   /glob-regex@0.3.2:
-    resolution: {integrity: sha1-JzSPL2BkjsMqSlMTcJC5+5NPNCU=}
+    resolution: {integrity: sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==}
     dev: false
 
   /glob-to-regexp@0.4.1:
@@ -7739,7 +7735,7 @@ packages:
     dev: false
 
   /globrex@0.1.2:
-    resolution: {integrity: sha1-3V2eyCYjJzDNZ5Ol4zqTApheYJg=}
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: false
 
   /gopd@1.0.1:
@@ -8064,8 +8060,8 @@ packages:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
     dev: false
 
-  /html-webpack-plugin@5.5.0(webpack@5.79.0):
-    resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
+  /html-webpack-plugin@5.5.1(webpack@5.79.0):
+    resolution: {integrity: sha512-cTUzZ1+NqjGEKjmVgZKLMdiFg3m9MdRXkZW2OEe69WYVi5ONLMmlnSZdXzGGMOq0C8jGDrL6EWyEDDUioHO/pA==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       webpack: ^5.20.0
@@ -8093,7 +8089,7 @@ packages:
       domelementtype: 2.3.0
       domhandler: 5.0.3
       domutils: 3.0.1
-      entities: 4.4.0
+      entities: 4.5.0
     dev: false
 
   /http-assert@1.5.0:
@@ -9819,7 +9815,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
       webpack: 5.79.0
     dev: false
 
@@ -9950,7 +9946,7 @@ packages:
     resolution: {integrity: sha512-jAlSOFR1Bls963NmFwxeQkNTzqjUF0NThm8Le7eRIRGzFUVJuMOFZDLv5Y30W/Oaw+KEebEJLAigwO9gQHoEmw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.4.0
+      semver: 7.5.0
     dev: false
 
   /node-addon-api@5.1.0:
@@ -10014,7 +10010,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.12.0
-      semver: 7.4.0
+      semver: 7.5.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -10349,7 +10345,7 @@ packages:
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
-      entities: 4.4.0
+      entities: 4.5.0
     dev: false
 
   /parseurl@1.3.3:
@@ -10634,7 +10630,7 @@ packages:
       cosmiconfig-typescript-loader: 4.3.0(@types/node@18.15.11)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.0.3)
       klona: 2.0.6
       postcss: 8.4.21
-      semver: 7.4.0
+      semver: 7.5.0
       ts-node: 10.9.1(@types/node@18.15.11)(typescript@5.0.3)
       typescript: 5.0.3
       webpack: 5.79.0
@@ -11549,7 +11545,7 @@ packages:
     dev: false
 
   /recrawl-sync@2.2.3:
-    resolution: {integrity: sha1-dXrc2q5HmUZt3luO5SEi/5Y237E=}
+    resolution: {integrity: sha512-vSaTR9t+cpxlskkdUFrsEpnf67kSmPk66yAGT1fZPrDudxQjoMzPgQhSMImQ0pAw5k0NPirefQfhopSjhdUtpQ==}
     dependencies:
       '@cush/relative': 1.0.0
       glob-regex: 0.3.2
@@ -11841,8 +11837,8 @@ packages:
       estree-walker: 0.6.1
     dev: false
 
-  /rollup@3.20.2:
-    resolution: {integrity: sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==}
+  /rollup@3.20.5:
+    resolution: {integrity: sha512-Mx6NE3nLPIP6a9ReV4dTPOYYmDiyarJNtSbc37Jx0jvh8SHySoFPgyZAp9aDP3LnYvaJOrz+fclcwq3oZDzlnA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -11939,8 +11935,8 @@ packages:
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: false
 
-  /schema-utils@3.1.1:
-    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
+  /schema-utils@3.1.2:
+    resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.11
@@ -11948,8 +11944,8 @@ packages:
       ajv-keywords: 3.5.2(ajv@6.12.6)
     dev: false
 
-  /schema-utils@4.0.0:
-    resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==}
+  /schema-utils@4.0.1:
+    resolution: {integrity: sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==}
     engines: {node: '>= 12.13.0'}
     dependencies:
       '@types/json-schema': 7.0.11
@@ -12000,8 +11996,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver@7.4.0:
-    resolution: {integrity: sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==}
+  /semver@7.5.0:
+    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -12110,7 +12106,7 @@ packages:
       detect-libc: 2.0.1
       node-addon-api: 5.1.0
       prebuild-install: 7.1.1
-      semver: 7.4.0
+      semver: 7.5.0
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
@@ -12214,7 +12210,7 @@ packages:
     dev: true
 
   /slash@3.0.0:
-    resolution: {integrity: sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=}
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   /slash@4.0.0:
@@ -12728,7 +12724,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       jest-worker: 27.5.1
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.16.9
       webpack: 5.79.0
@@ -12901,7 +12897,7 @@ packages:
       yn: 3.1.1
 
   /tsconfig-paths@4.2.0:
-    resolution: {integrity: sha1-73jhkDkTNEbSRL6sD9ahYy4tEHw=}
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
     dependencies:
       json5: 2.2.3
@@ -12952,7 +12948,7 @@ packages:
     dev: false
 
   /turbo-darwin-64@1.9.1:
-    resolution: {integrity: sha1-HwTnFq1s8HGCLwwaSZ9PzXvUD0s=}
+    resolution: {integrity: sha512-IX/Ph4CO80lFKd9pPx3BWpN2dynt6mcUFifyuHUNVkOP1Usza/G9YuZnKQFG6wUwKJbx40morFLjk1TTeLe04w==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -12960,7 +12956,7 @@ packages:
     optional: true
 
   /turbo-darwin-arm64@1.9.1:
-    resolution: {integrity: sha1-GewWGFj7Jt+9Up4OydbJtEhOkbA=}
+    resolution: {integrity: sha512-6tCbmIboy9dTbhIZ/x9KIpje73nvxbiyVnHbr9xKnsxLJavD0xqjHZzbL5U2tHp8chqmYf0E4WYOXd+XCNg+OQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -12968,7 +12964,7 @@ packages:
     optional: true
 
   /turbo-linux-64@1.9.1:
-    resolution: {integrity: sha1-W0fg8JEvcJqaLjJf6qfiYKp2z0k=}
+    resolution: {integrity: sha512-ti8XofnJFO1XaadL92lYJXgxb0VBl03Yu9VfhxkOTywFe7USTLBkJcdvQ4EpFk/KZwLiTdCmT2NQVxsG4AxBiQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -12976,7 +12972,7 @@ packages:
     optional: true
 
   /turbo-linux-arm64@1.9.1:
-    resolution: {integrity: sha1-2wNQYXYOhRKkCKZMwtfVaPUQKrc=}
+    resolution: {integrity: sha512-XYvIbeiCCCr+ENujd2Jtck/lJPTKWb8T2MSL/AEBx21Zy3Sa7HgrQX6LX0a0pNHjaleHz00XXt1D0W5hLeP+tA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -12984,7 +12980,7 @@ packages:
     optional: true
 
   /turbo-windows-64@1.9.1:
-    resolution: {integrity: sha1-Vq2Y5HAbRSPxGDl9mNZOvvXauI8=}
+    resolution: {integrity: sha512-x7lWAspe4/v3XQ0gaFRWDX/X9uyWdhwFBPEfb8BA0YKtnsrPOHkV0mRHCRrXzvzjA7pcDCl2agGzb7o863O+Jg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -12992,7 +12988,7 @@ packages:
     optional: true
 
   /turbo-windows-arm64@1.9.1:
-    resolution: {integrity: sha1-8MeAzJBt7f+F7vIPBj9ZqbKoZfw=}
+    resolution: {integrity: sha512-QSLNz8dRBLDqXOUv/KnoesBomSbIz2Huef/a3l2+Pat5wkQVgMfzFxDOnkK5VWujPYXz+/prYz+/7cdaC78/kw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -13287,8 +13283,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /update-browserslist-db@1.0.10(browserslist@4.21.5):
-    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+  /update-browserslist-db@1.0.11(browserslist@4.21.5):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -13312,7 +13308,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.4.0
+      semver: 7.5.0
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: false
@@ -13335,7 +13331,7 @@ packages:
       file-loader: 6.2.0(webpack@5.79.0)
       loader-utils: 2.0.4
       mime-types: 2.1.35
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       webpack: 5.79.0
     dev: false
 
@@ -13506,7 +13502,7 @@ packages:
     dev: true
 
   /vite-tsconfig-paths@3.6.0(vite@4.2.1):
-    resolution: {integrity: sha1-nmNjBRssqvfHzsb5+FrXH+7neSA=}
+    resolution: {integrity: sha512-UfsPYonxLqPD633X8cWcPFVuYzx/CMNHAjZTasYwX69sXpa4gNmQkR0XCjj82h7zhLGdTWagMjC1qfb9S+zv0A==}
     peerDependencies:
       vite: '>2.0.0-0'
     dependencies:
@@ -13545,10 +13541,10 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.15.11
-      esbuild: 0.17.16
+      esbuild: 0.17.17
       postcss: 8.4.21
       resolve: 1.22.2
-      rollup: 3.20.2
+      rollup: 3.20.5
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -13706,16 +13702,16 @@ packages:
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
-      colorette: 2.0.19
+      colorette: 2.0.20
       memfs: 3.5.0
       mime-types: 2.1.35
       range-parser: 1.2.1
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
       webpack: 5.79.0
     dev: false
 
-  /webpack-dev-server@4.13.2(webpack@5.79.0):
-    resolution: {integrity: sha512-5i6TrGBRxG4vnfDpB6qSQGfnB6skGBXNL5/542w2uRGLimX6qeE5BQMLrzIC3JYV/xlGOv+s+hTleI9AZKUQNw==}
+  /webpack-dev-server@4.13.3(webpack@5.79.0):
+    resolution: {integrity: sha512-KqqzrzMRSRy5ePz10VhjyL27K2dxqwXQLP5rAKwRJBPUahe7Z2bBWzHw37jeb8GCPKxZRO79ZdQUAPesMh/Nug==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
@@ -13737,7 +13733,7 @@ packages:
       ansi-html-community: 0.0.8
       bonjour-service: 1.1.1
       chokidar: 3.5.3
-      colorette: 2.0.19
+      colorette: 2.0.20
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
@@ -13750,7 +13746,7 @@ packages:
       open: 8.4.2
       p-retry: 4.6.2
       rimraf: 3.0.2
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
       selfsigned: 2.1.1
       serve-index: 1.9.1
       sockjs: 0.3.24
@@ -13807,7 +13803,7 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.7(webpack@5.79.0)
       watchpack: 2.4.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "paths": {
-      "virtual:generated-list": ["./packages/ladle/types/generated-list.d.ts"]
+      "virtual:generated-list": ["./packages/ladle/types/generated-list.d.ts"],
+      "@/*": ["./e2e/config-ts/src/to/*"]
     }
   },
   "include": [


### PR DESCRIPTION
fixes #417

version 4+ causing issue in https://github.com/janakg/tsconfig-path-lib-path-issue
added a test into our monorepo, strangely works for 3.6 and 4.1+ but not for 4.0

pinning it down to 3.6.0 since that works in both setups