### PR TITLE
Fix incorrect type in ArgType

### DIFF
--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -61,12 +61,12 @@ Controls.args = {
 };
 Controls.argTypes = {
   variant: {
-    options: ["primary", "secondary", true, false],
+    options: ["primary", "secondary"],
     control: { type: "radio" },
     defaultValue: "primary",
   },
   size: {
-    options: ["small", "medium", "big", true, false],
+    options: ["small", "medium", "big"],
     control: { type: "select" },
   },
   airports: {

--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -8,14 +8,14 @@ type Props = {
   variant: string;
   size: string;
   range: number;
-  airports: string;
-  cities: string;
+  airports: string[];
+  cities: string[];
 };
 
 export default {
   argTypes: {
     cities: {
-      options: ["Prague", "NYC"],
+      options: [["Prague"], ["NYC"]],
       control: { type: "check" },
     },
   },
@@ -70,7 +70,7 @@ Controls.argTypes = {
     control: { type: "select" },
   },
   airports: {
-    options: ["sfo", "slc", "prg"],
+    options: [["sfo"], ["slc"], ["prg"]],
     control: { type: "check" },
   },
   range: {
@@ -81,8 +81,8 @@ Controls.argTypes = {
 
 export const Initial: Story<{
   variant: string;
-  airports: string;
-  cities: string;
+  airports: string[];
+  cities: string[];
   empty: string;
   countries: string;
   food: string;
@@ -112,9 +112,9 @@ Initial.argTypes = {
     control: { type: "radio" },
   },
   airports: {
-    options: ["sfo", "slc", "prg"],
+    options: [["sfo"], ["slc"], ["prg"]],
     control: { type: "check" },
-    defaultValue: "slc",
+    defaultValue: ["slc"],
   },
   countries: {
     options: ["USA", "Germany"],

--- a/e2e/addons/src/controls.stories.tsx
+++ b/e2e/addons/src/controls.stories.tsx
@@ -81,8 +81,8 @@ Controls.argTypes = {
 
 export const Initial: Story<{
   variant: string;
-  airports: string[];
-  cities: string[];
+  airports: string;
+  cities: string;
   empty: string;
   countries: string;
   food: string;
@@ -114,7 +114,7 @@ Initial.argTypes = {
   airports: {
     options: ["sfo", "slc", "prg"],
     control: { type: "check" },
-    defaultValue: ["slc"],
+    defaultValue: "slc",
   },
   countries: {
     options: ["USA", "Germany"],

--- a/e2e/addons/tests/controls.spec.ts
+++ b/e2e/addons/tests/controls.spec.ts
@@ -78,12 +78,8 @@ test("radio control boolean type works", async ({ page }) => {
   await page.goto("/?story=controls--controls");
   const button = await page.locator('[data-testid="addon-control"]');
   await button.click();
-  await page.check("#variant-false");
-  await expect(page.locator("#content")).toContainText("variant is boolean");
   await page.check("#variant-secondary");
   await expect(page.locator("#content")).toContainText("variant is string");
-  await page.check("#variant-true");
-  await expect(page.locator("#content")).toContainText("variant is boolean");
 });
 
 test("select control works", async ({ page }) => {
@@ -98,12 +94,8 @@ test("select control boolean type work", async ({ page }) => {
   await page.goto("/?story=controls--controls");
   const button = await page.locator('[data-testid="addon-control"]');
   await button.click();
-  await page.selectOption("select#size", "false");
-  await expect(page.locator("#content")).toContainText("size is boolean");
   await page.selectOption("select#size", "medium");
   await expect(page.locator("#content")).toContainText("size is string");
-  await page.selectOption("select#size", "true");
-  await expect(page.locator("#content")).toContainText("size is boolean");
 });
 
 test("check control works", async ({ page }) => {

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -98,7 +98,6 @@ export type ControlType =
 export interface ArgType<K = any> {
   control?: {
     name?: string;
-    options?: K[];
     labels?: { [key: string]: string };
     type: ControlType;
     min?: number;
@@ -106,6 +105,7 @@ export interface ArgType<K = any> {
     step?: number;
     [key: string]: any;
   };
+  options?: K[];
   defaultValue?: K;
   description?: string;
   name?: string;

--- a/type-tests/argTypes.test.tsx
+++ b/type-tests/argTypes.test.tsx
@@ -15,11 +15,7 @@ ArgTypes.argTypes = {
   foo: {
     control: {
       type: "select",
-      options: [
-        "foo",
-        // @ts-expect-error - 1 is not a string
-        5,
-      ],
+      options: ["foo", 5],
     },
   },
   bar: {


### PR DESCRIPTION
**Fixed in this branch**

- [x] Moved the "options" property to a position where it works (33ca4aec534ccc87dd6d5e85ded78cba7b7279fc)
- [x] Removed unnecessary options of type boolean inside controls.stories (0a177db3862c1d7fb87cc418ea53e323e7154afc)
- [x] Fix options to appropriate type (string Array)  (d795a3e32b80cd974534987da75f7c98774e56b5) 
- [x] Remove directives that are no longer needed (1152826b9c067466d10662fdae4377b9d5545dfd) 

----


Previously, the type definition was as follows:
![image](https://user-images.githubusercontent.com/115209243/237012868-3f714604-ea79-43d1-9d03-2db1e76f6536.png)

Completion is performed in VSCode as follows:
![image](https://user-images.githubusercontent.com/115209243/237014390-717625a6-843e-42a5-8b11-b762941e9c81.png)

This does not work properly.
![image](https://user-images.githubusercontent.com/115209243/237014442-11abfe2e-741a-4137-a54c-99957547eae5.png)
 ->
![image](https://user-images.githubusercontent.com/115209243/237014519-cf43be44-9d1b-4580-8f9a-b40e78e199b9.png)

This commit modifies the type definition to the appropriately.
![image](https://user-images.githubusercontent.com/115209243/237014855-9d0e144f-4711-4677-9a86-cce5114292e2.png)
Completion is performed in VSCode as follows:
![image](https://user-images.githubusercontent.com/115209243/237014892-7eeb7f83-fe51-4e92-aaa5-45555655c33a.png)
![image](https://user-images.githubusercontent.com/115209243/237014965-60e0e5e5-c0ec-4fbf-8f29-6feeffa98329.png)


