### PR TITLE
Changes Meta from a type to an interface

### DIFF
--- a/.changeset/eight-cobras-add.md
+++ b/.changeset/eight-cobras-add.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Changes Meta from a type to an interface so it can be extended by declaring a module

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -122,8 +122,8 @@ export type ArgTypes<
   [key in keyof P]?: ArgType<P[key]>;
 };
 
-export type Meta = {
+export interface Meta {
   iframed?: boolean;
   width?: number | "xsmall" | "small" | "medium" | "large";
   [key: string]: any;
-};
+}


### PR DESCRIPTION
This allows extending the interface to define custom meta types within your own implementation.

```ts
declare module "@ladle/react" {
  export interface Meta {
    myCustomMeta: string;
  }
}
```