### PR TITLE
Add nextjs env file handling to docs

### DIFF
--- a/packages/website/docs/nextjs.md
+++ b/packages/website/docs/nextjs.md
@@ -42,3 +42,20 @@ export default UnoptimizedImage;
 ```
 
 This solution is inspired by [blog post](https://sdorra.dev/posts/2023-01-18-ladle-next-image#nextimage).
+
+## Using environment variables
+
+To make use of your current `.env` files, you simply need to let Vite know and ensure they are passed to the browser. As Next.js requires you to add `NEXT_PUBLIC_` as a prefix to your frontend environment variables, we also need to inform Vite about this.
+
+To achieve this, you will need to customize Vite's configuration further.
+
+```ts title="vite.config.ts"
+import { defineConfig, loadEnv } from "vite";
+
+export default defineConfig(({ mode }) => ({
+  // resolve: {...},
+  define: {
+    "process.env": loadEnv(mode, process.cwd(), "NEXT_PUBLIC_"),
+  },
+}));
+```


### PR DESCRIPTION
Hello there! 👋🏻

As discussed on Discord, it took me a while to make Ladle and Next.js work together due to my use of frontend environment variables.

I have included a brief explanation and code snippet in the existing Next.js documentation. Please let me know if anything is unclear or if there's anything missing. 😇

Here is my original message from Discord:

> Hello there! 👋🏻 I encountered some difficulties while trying to make Ladle and Next.js work together. At first, I realized that I needed to inform Ladle to include the .env.local file. Fortunately, I came across this helpful resource: [Ladle Documentation](https://ladle.dev/docs/nextjs). However, it didn't provide any information about environment variables. After some time, I discovered that I needed to utilize the Vite config to inject all the variables. Initially, it didn't work because Next.js prefixes the variables exposed to the frontend with "NEXT_". But then I found out that Vite offers a solution for this through vita.loadEnv.
All of these steps felt a little strange, so I wanted to ask if a) I'm doing something wrong or b) I should open a pull request to add this information to the Ladle documentation.