### PR TITLE
Fix docs on default width

### DIFF
--- a/packages/website/docs/width.mdx
+++ b/packages/website/docs/width.mdx
@@ -34,7 +34,7 @@ export default {
         large: 1200,
       },
       enabled: true, // the addon can be disabled
-      defaultValue: 0, // 0 = no viewport is set
+      defaultState: 0, // default width in pixels (0 = no viewport is set)
     },
   },
 };


### PR DESCRIPTION
I had to dig in to the code to find out why the `defaultValue` didn't work. Maybe the name of the variable has changed and docs not updated.