### PR TITLE
Switch rotated chevron icon

### DIFF
--- a/.changeset/cuddly-students-destroy.md
+++ b/.changeset/cuddly-students-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Switch rotated chevron icon

--- a/packages/ladle/lib/app/src/icons.tsx
+++ b/packages/ladle/lib/app/src/icons.tsx
@@ -141,12 +141,12 @@ export const Down = ({ rotate }: { rotate?: boolean }) => {
       {rotate ? (
         <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
           <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-          <path d="M6 9l6 6l6 -6"></path>
+          <path d="M9 6l6 6l-6 6"></path>
         </svg>
       ) : (
         <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
           <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-          <path d="M9 6l6 6l-6 6"></path>
+          <path d="M6 9l6 6l6 -6"></path>
         </svg>
       )}
     </div>


### PR DESCRIPTION
Previously, the first svg in the ternary operation was the chevron pointing down. When "rotate" is true, we should return the chevron pointing right instead.

Fixes #502 

## References

* https://github.com/tajo/ladle/issues/502
* https://github.com/tajo/ladle/pull/495