### PR TITLE
Add --noWatch option to serve command

### DIFF
--- a/.changeset/itchy-peas-repeat.md
+++ b/.changeset/itchy-peas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Add --noWatch option to serve command

--- a/packages/ladle/lib/cli/cli.js
+++ b/packages/ladle/lib/cli/cli.js
@@ -24,6 +24,7 @@ program
   .option("--viteConfig [string]", "file with Vite configuration")
   .option("--base [string]", "base URL path for build output")
   .option("--mode [string]", "Vite mode")
+  .option("--noWatch", "Disable file system watching")
   .action(serve);
 
 program
@@ -55,7 +56,11 @@ program
   .option("--base [string]", "base URL path for build output")
   .option("--mode [string]", "Vite mode")
   .action(async (params) => {
-    await preview({ ...params, previewHost: params.host, previewPort: params.port });
+    await preview({
+      ...params,
+      previewHost: params.host,
+      previewPort: params.port,
+    });
   });
 
 program.parse(process.argv);

--- a/packages/ladle/lib/shared/default-config.js
+++ b/packages/ladle/lib/shared/default-config.js
@@ -7,6 +7,7 @@ export default {
   storyOrder: (stories) => stories, // default is alphabetical
   viteConfig: undefined,
   appendToHead: "",
+  noWatch: false,
   port: 61000,
   previewPort: 8080,
   outDir: "build",

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -186,6 +186,7 @@ export type Config = {
   outDir: string;
   base?: string;
   mode?: string;
+  noWatch?: boolean;
   hotkeys: {
     fullscreen: string[];
     search: string[];

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -186,7 +186,7 @@ export type Config = {
   outDir: string;
   base?: string;
   mode?: string;
-  noWatch?: boolean;
+  noWatch: boolean;
   hotkeys: {
     fullscreen: string[];
     search: string[];

--- a/packages/website/docs/cli.md
+++ b/packages/website/docs/cli.md
@@ -34,6 +34,7 @@ Options:
   --viteConfig [string]  file with Vite configuration
   --base [string]        base URL path for build output
   --mode [string]        Vite mode
+  --noWatch [string]     disable file system watcher
   -h, --help             display help for command
 
 ```

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -298,3 +298,14 @@ export default {
   },
 };
 ```
+
+### noWatch
+
+Disable the file system watcher when running the `serve` cli command.
+
+```js
+/** @type {import('@ladle/react').UserConfig} */
+export default {
+  noWatch: true,
+};
+```


### PR DESCRIPTION
When running in a multi tenant environment, we're seeing instances where chokidar exceeds the available `max_user_watches`, with the error message `System limit for number of file watchers reached, watch 'src'`. While we could increase that limit, there is no reason to watch the file system in this scenario. Making this change within ladle, rather than customizing through `vite.config.js` is important because ladle starts its own chokidar watch outside of vite.

This PR adds a `--noWatch` option to the serve command to disable chokidar file system watching. It currently does this by adding all files to the [`ignored` watcher options](https://vitejs.dev/config/server-options.html#server-watch). A [recent PR](https://github.com/vitejs/vite/pull/14208) to vite added `null` as an acceptable value to achieve the same result, but it has not been included in a release yet. I added a `TODO` comment in the code to update once available.