### PR TITLE
ladle.css leaks on @reach/dialog

### DIFF
--- a/.changeset/real-dingos-remain.md
+++ b/.changeset/real-dingos-remain.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Scope @reach/dialog styles in ladle.css to prevent leaking on user stories

--- a/packages/ladle/lib/app/ladle.css
+++ b/packages/ladle/lib/app/ladle.css
@@ -446,7 +446,7 @@ body {
   }
 }
 
-div[data-reach-dialog-content] {
+div[data-reach-dialog-content][data-testid="ladle-dialog"] {
   box-shadow: 0 1px 2px hsla(0, 0%, 0%, 0.16);
   outline: none;
   font-family: Arial, Helvetica, sans-serif;
@@ -461,11 +461,11 @@ div[data-reach-dialog-content] {
   overflow: none;
 }
 
-div[data-reach-dialog-content] a {
+div[data-reach-dialog-content][data-testid="ladle-dialog"] a {
   color: var(--ladle-color-accent);
 }
 
-div[data-reach-dialog-overlay] {
+div[data-reach-dialog-overlay][data-testid="ladle-dialog-overlay"] {
   position: fixed;
   top: 0;
   right: 0;
@@ -690,7 +690,7 @@ blockquote.ladle-markdown {
     display: none;
   }
 
-  div[data-reach-dialog-content] {
+  div[data-reach-dialog-content][data-testid="ladle-dialog"] {
     position: fixed;
     bottom: 49px;
     inset-inline-start: 21px;

--- a/packages/ladle/lib/app/src/ui.tsx
+++ b/packages/ladle/lib/app/src/ui.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { Dialog } from "./dialog";
+import { DialogOverlay, DialogContent } from "./dialog";
 import { Close } from "./icons";
 
 export const Button = ({
@@ -61,34 +61,39 @@ export const Modal = ({
 }) => {
   return (
     //@ts-ignore
-    <Dialog
+    <DialogOverlay
       isOpen={isOpen}
       onDismiss={() => close()}
-      aria-label={label || "Modal"}
-      data-testid="ladle-dialog"
-      style={{ maxWidth }}
+      data-testid="ladle-dialog-overlay"
     >
-      <div
-        style={{
-          position: "absolute",
-          insetInlineEnd: "-6px",
-          top: "0px",
-        }}
+      {/* @ts-ignore */}
+      <DialogContent
+        aria-label={label || "Modal"}
+        data-testid="ladle-dialog"
+        style={{ maxWidth }}
       >
-        <Button
-          onClick={() => close()}
-          aria-label="Close modal"
+        <div
           style={{
-            height: "36px",
-            width: "36px",
-            borderColor: "transparent",
-            boxShadow: "none",
+            position: "absolute",
+            insetInlineEnd: "-6px",
+            top: "0px",
           }}
         >
-          <Close />
-        </Button>
-      </div>
-      <div className="ladle-addon-modal-body">{children}</div>
-    </Dialog>
+          <Button
+            onClick={() => close()}
+            aria-label="Close modal"
+            style={{
+              height: "36px",
+              width: "36px",
+              borderColor: "transparent",
+              boxShadow: "none",
+            }}
+          >
+            <Close />
+          </Button>
+        </div>
+        <div className="ladle-addon-modal-body">{children}</div>
+      </DialogContent>
+    </DialogOverlay>
   );
 };


### PR DESCRIPTION
Fix for #535

I didn't end up using the patch from the issue to avoid using `:has` which still has [limited browser support](https://caniuse.com/css-has)