### PR TITLE
Fix typos in documentation

### DIFF
--- a/packages/website/blog/2023-09-19-ladle-v3.md
+++ b/packages/website/blog/2023-09-19-ladle-v3.md
@@ -42,7 +42,7 @@ Recent additions include:
 
 ## Lessons Learned
 
-The primary catalyst behind Ladle was performance enhancement. Incremental builds transitioned from several seconds or even minutes to mere milliseconds. Startup durations reduced dramatically. And bellow a chart showcases our progression to a 100% Ladle adoption by 08/2023 and its impact on CI build times.
+The primary catalyst behind Ladle was performance enhancement. Incremental builds transitioned from several seconds or even minutes to mere milliseconds. Startup durations reduced dramatically. And, below, a chart showcases our progression to a 100% Ladle adoption by 08/2023 and its impact on CI build times.
 
 ![Production build times](/img/build-times.png)
 

--- a/packages/website/docs/decorators.md
+++ b/packages/website/docs/decorators.md
@@ -39,7 +39,7 @@ MyStory.decorators = [
 
 ## Context Parameter
 
-You can also access Ladle's context through the second parameter. This way your decorators can control every aspect of Ladle including the state of controls and other addons:
+You can also access Ladle's context through the second parameter. This way, your decorators can control every aspect of Ladle, including the state of controls and other addons:
 
 ```tsx
 import type { StoryDefault, Story } from "@ladle/react";

--- a/packages/website/docs/decorators.md
+++ b/packages/website/docs/decorators.md
@@ -3,7 +3,7 @@ id: decorators
 title: Decorators
 ---
 
-Ladle supports story decorators, so you can wrap all stories in a file with additional React component(s). This is useful if your stories/components rely on [React Context](https://reactjs.org/docs/context.html) and libraries like `react-router`, `redux` or [next](https://ladle.dev/docs/nextjs/). In the example bellow , we are adding an extra `margin: 3em` to each story:
+Ladle supports story decorators, so you can wrap all stories in a file with additional React component(s). This is useful if your stories/components rely on [React Context](https://reactjs.org/docs/context.html) and libraries like `react-router`, `redux` or [next](https://ladle.dev/docs/nextjs/). In the example below, we are adding an extra `margin: 3em` to each story:
 
 ```tsx
 import type { StoryDefault } from "@ladle/react";


### PR DESCRIPTION
- Fixed the spelling of the word, "below"
- Added commas in an attempt to make a sentence easier for people to read