### PR TITLE
Update documentation Next.js runtime library import path

### DIFF
--- a/packages/website/docs/nextjs.md
+++ b/packages/website/docs/nextjs.md
@@ -51,7 +51,7 @@ You could solve it by setting [Providers](/docs/providers).
 
 ```tsx title=".ladle/components.tsx"
 import { GlobalProvider } from "@ladle/react";
-import { AppRouterContext } from "next/dist/shared/lib/app-router-context";
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 export const Provider: GlobalProvider = ({ children }) => {
   return (
@@ -87,7 +87,7 @@ Or if you want to set it in each file, you could use [Decorators](/docs/decorato
 
 ```tsx title="./Hello.stories.tsx"
 import type { StoryDefault, Story } from "@ladle/react";
-import { AppRouterContext } from "next/dist/shared/lib/app-router-context";
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { useRouter } from "next/navigation";
 
 export default {


### PR DESCRIPTION
Hi, thanks for your work on Ladle! It's a really nice tool!

The path to AppRouterContext was moved a few months back. This small patch updates the documentation with the new import path.

See https://github.com/vercel/next.js/commit/a5b7c77c1ff0096af7609a8bfc1e064d30db4e30#diff-421107ce62efb02560358d25c5eb086d5d82d2ad1c7c4929ebfb768c2ea1c973 for upstream next.js changes