### PR TITLE
Adds MetaJson types

### DIFF
--- a/.changeset/dirty-zoos-jam.md
+++ b/.changeset/dirty-zoos-jam.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Exports meta.json types from library

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -8,12 +8,15 @@ import {
   ModeState,
   GlobalAction,
   Config,
+  KnownMeta,
+  MetaJson as BaseMetaJson,
+  MetaJsonStory as BaseMetaJsonStory,
 } from "../shared/types";
 
 import * as msw from "msw";
 export { msw };
 
-export type { UserConfig, MetaJson, MetaJsonStory } from "../shared/types";
+export type { UserConfig } from "../shared/types";
 export { useMDXComponents } from "@mdx-js/react";
 export const Story = (props: any) => props.children;
 export const Meta = (props: any) => props.children;
@@ -135,9 +138,9 @@ export type ArgTypes<
   [key in keyof P]?: ArgType<P[key]>;
 };
 
-export interface Meta {
-  iframed?: boolean;
-  width?: string | number | "xsmall" | "small" | "medium" | "large";
-  mockDate?: string;
+export interface Meta extends KnownMeta {
   [key: string]: any;
 }
+
+export type MetaJson = BaseMetaJson<Meta>;
+export type MetaJsonStory = BaseMetaJsonStory<Meta>;

--- a/packages/ladle/lib/app/exports.ts
+++ b/packages/ladle/lib/app/exports.ts
@@ -13,7 +13,7 @@ import {
 import * as msw from "msw";
 export { msw };
 
-export type { UserConfig } from "../shared/types";
+export type { UserConfig, MetaJson, MetaJsonStory } from "../shared/types";
 export { useMDXComponents } from "@mdx-js/react";
 export const Story = (props: any) => props.children;
 export const Meta = (props: any) => props.children;

--- a/packages/ladle/lib/cli/vite-plugin/generate/get-meta-json.js
+++ b/packages/ladle/lib/cli/vite-plugin/generate/get-meta-json.js
@@ -2,6 +2,7 @@ import { storyIdToMeta } from "../naming-utils.js";
 
 /**
  * @param entryData {import('../../../shared/types').EntryData}
+ * @returns {import('../../../shared/types').MetaJson}
  */
 export const getMetaJson = (entryData) => {
   /** @type {string[]} */
@@ -20,14 +21,15 @@ export const getMetaJson = (entryData) => {
     );
     storyParams = { ...storyParams, ...entryData[entry].storyParams };
   });
+
+  /** @type {import('../../../shared/types').MetaJson} */
   const result = {
     about: {
       homepage: "https://www.ladle.dev",
       github: "https://github.com/tajo/ladle",
       version: 1,
     },
-    stories:
-      /** @type {{[key: string]: {name: string; levels: string[]; meta: any, locStart: number; locEnd: number;}}} */ ({}),
+    stories: {},
   };
   storyIds.forEach((storyId) => {
     result.stories[storyId] = {

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -280,3 +280,20 @@ export type GetUserViteConfig = {
 export type EntryData = {
   [key: string]: ParsedStoriesResult;
 };
+
+export type MetaJson = {
+  about: {
+    homepage: string;
+    github: string;
+    version: number;
+  };
+  stories: { [key: string]: MetaJsonStory };
+};
+
+export type MetaJsonStory = {
+  name: string;
+  levels: string[];
+  meta: any;
+  locStart: number;
+  locEnd: number;
+};

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -281,7 +281,7 @@ export type EntryData = {
   [key: string]: ParsedStoriesResult;
 };
 
-export type MetaJson<M = any> = {
+export type MetaJson<M extends KnownMeta = KnownMeta> = {
   about: {
     homepage: string;
     github: string;
@@ -290,10 +290,16 @@ export type MetaJson<M = any> = {
   stories: { [key: string]: MetaJsonStory<M> };
 };
 
-export type MetaJsonStory<M = any> = {
+export type MetaJsonStory<M extends KnownMeta = KnownMeta> = {
   name: string;
   levels: string[];
   meta: M;
   locStart: number;
   locEnd: number;
 };
+
+export interface KnownMeta {
+  iframed?: boolean;
+  width?: string | number | "xsmall" | "small" | "medium" | "large";
+  mockDate?: string;
+}

--- a/packages/ladle/lib/shared/types.ts
+++ b/packages/ladle/lib/shared/types.ts
@@ -281,19 +281,19 @@ export type EntryData = {
   [key: string]: ParsedStoriesResult;
 };
 
-export type MetaJson = {
+export type MetaJson<M = any> = {
   about: {
     homepage: string;
     github: string;
     version: number;
   };
-  stories: { [key: string]: MetaJsonStory };
+  stories: { [key: string]: MetaJsonStory<M> };
 };
 
-export type MetaJsonStory = {
+export type MetaJsonStory<M = any> = {
   name: string;
   levels: string[];
-  meta: any;
+  meta: M;
   locStart: number;
   locEnd: number;
 };


### PR DESCRIPTION
I'm using [visual snapshots](https://ladle.dev/blog/visual-snapshots/) in my project, and our TypeScript rules in the project dictate that I needed to define the type for the shape of the meta.json file.

I figured it might be a good idea to formally define these types in the project and export them for consumers of the library in case the shape changes in the future.