### PR TITLE
Updates pnpm/action-setup to v4 in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4
         with:
           version: 9.1.4
 


### PR DESCRIPTION
 It looks like #564 missed updating the pnpm/action-setup version in the ci.yml workflow, so CI is failing on a couple of PRs I opened a few days ago.