### PR TITLE
Improve UnoptimizedImage docs

### DIFF
--- a/packages/website/docs/nextjs.md
+++ b/packages/website/docs/nextjs.md
@@ -35,9 +35,29 @@ export default UnoptimizedLink;
 ```
 
 ```tsx title=".ladle/UnoptimizedImage.tsx"
-const UnoptimizedImage = (props: any) => {
-  return <img {...props} />;
+import React from 'react';
+
+interface UnoptimizedImageProps
+  extends React.ImgHTMLAttributes<HTMLImageElement> {
+  fill?: boolean;
+}
+
+const UnoptimizedImage: React.FC<UnoptimizedImageProps> = ({
+  fill,
+  ...props
+}) => {
+  const style: React.CSSProperties = fill
+    ? {
+        position: 'absolute',
+        inset: '0',
+        width: '100%',
+        height: '100%',
+      }
+    : {};
+
+  return <img {...props} style={style} />;
 };
+
 export default UnoptimizedImage;
 ```
 


### PR DESCRIPTION
When working with nextjs, image component has "fill" property. If not handled correctly, components in Ladle look different than on the page.