### PR TITLE
`TITLE` string const as fallback for `meta.title` default export

### DIFF
--- a/packages/ladle/lib/cli/vite-plugin/parse/get-entry-data.js
+++ b/packages/ladle/lib/cli/vite-plugin/parse/get-entry-data.js
@@ -7,6 +7,7 @@ import getAst from "../get-ast.js";
 import getDefaultExport from "./get-default-export.js";
 import getStorynameAndMeta from "./get-storyname-and-meta.js";
 import getNamedExports from "./get-named-exports.js";
+import getTitleExport from "./get-title-export.js";
 import { IMPORT_ROOT } from "../utils.js";
 import mdxToStories from "../mdx-to-stories.js";
 
@@ -53,10 +54,15 @@ export const getSingleEntry = async (entry) => {
   //@ts-ignore
   const ast = getAst(code, entry);
   traverse(ast, {
-    Program: getStorynameAndMeta.bind(this, result),
-  });
-  traverse(ast, {
     ExportDefaultDeclaration: getDefaultExport.bind(this, result),
+  });
+  if (!result.exportDefaultProps.title) {
+    traverse(ast, {
+      ExportNamedDeclaration: getTitleExport.bind(this, result),
+    });
+  }
+  traverse(ast, {
+    Program: getStorynameAndMeta.bind(this, result),
   });
   traverse(ast, {
     ExportNamedDeclaration: getNamedExports.bind(this, result),

--- a/packages/ladle/lib/cli/vite-plugin/parse/get-named-exports.js
+++ b/packages/ladle/lib/cli/vite-plugin/parse/get-named-exports.js
@@ -23,6 +23,8 @@ const getNamedExports = (
   },
   astPath,
 ) => {
+  if (!astPath?.node?.declaration && !astPath?.node?.specifiers) return;
+
   /**
    * @param {any} namedExportDeclaration
    * @param {string} namedExport
@@ -79,7 +81,10 @@ const getNamedExports = (
     if (namedExportDeclaration.type === "ClassDeclaration") {
       namedExport = namedExportDeclaration.id.name;
     } else if (namedExportDeclaration.type === "VariableDeclaration") {
-      namedExport = namedExportDeclaration.declarations[0].id.name;
+      // Skip TITLE constant export
+      const declaration = namedExportDeclaration.declarations[0];
+      if (declaration.id.name === "TITLE") return;
+      namedExport = declaration.id.name;
     } else if (namedExportDeclaration.type === "FunctionDeclaration") {
       namedExport = namedExportDeclaration.id.name;
     } else {
@@ -94,6 +99,8 @@ const getNamedExports = (
     astPath.node?.specifiers.forEach(
       /** type * @param {any} specifier */
       (specifier) => {
+        // Skip TITLE export
+        if (specifier.exported.name === "TITLE") return;
         const namedExport = specifier.exported.name;
         const story = namedExportToStory(specifier, namedExport);
         stories.push(story);

--- a/packages/ladle/lib/cli/vite-plugin/parse/get-title-export.js
+++ b/packages/ladle/lib/cli/vite-plugin/parse/get-title-export.js
@@ -1,0 +1,23 @@
+/**
+ * @param {import('../../../shared/types').ParsedStoriesResult} result
+ * @param {any} astPath
+ */
+const getTitleExport = (result, astPath) => {
+  if (!astPath?.node?.declaration) return;
+
+  if (astPath.node.declaration.type === "VariableDeclaration") {
+    const declarations = astPath.node.declaration.declarations;
+
+    for (const declaration of declarations) {
+      if (declaration.id.name === "TITLE") {
+        if (declaration.init.type !== "StringLiteral") {
+          throw new Error("TITLE export must be a string literal.");
+        }
+        result.exportDefaultProps.title = declaration.init.value;
+        return;
+      }
+    }
+  }
+};
+
+export default getTitleExport;

--- a/packages/ladle/tests/fixtures/title-constant.stories.tsx
+++ b/packages/ladle/tests/fixtures/title-constant.stories.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const TITLE = "Constant Title";
+
+export const Story = () => {
+  return <h1>Story</h1>;
+};

--- a/packages/ladle/tests/parse/get-entry-data.test.ts
+++ b/packages/ladle/tests/parse/get-entry-data.test.ts
@@ -54,3 +54,10 @@ test("Extract and merge story meta", async () => {
   );
   expect(entryData).toMatchSnapshot();
 });
+
+test("TITLE constant is used when no default title exists", async () => {
+  const entryData = await getSingleEntry(
+    "tests/fixtures/title-constant.stories.tsx",
+  );
+  expect(entryData.exportDefaultProps.title).toBe("Constant Title");
+});


### PR DESCRIPTION
Since the default export of a non-primitive value breaks react-refresh functionality in Vite, this PR proposes an alternative for providing a Story title that is react-refresh compatible:

Instead of this:
```tsx
export default { title: "My/Story/Path" }
```

Do this:
```tsx
export const TITLE = "My/Story/Path"
```