### PR TITLE
Note on powershell in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ mkdir src
 echo "export const World = () => <p>Hey</p>;" > src/hello.stories.tsx
 npx ladle serve
 ```
+
+For powershell, replace in the above listings echo with the following
+
+```powershell
+@"
+export const World = () => <p>Hey</p>;
+"@ | out-file -encoding ASCII src/hello.stories.tsx
+```


### PR DESCRIPTION
Adding note about powershell for the quick start.

Running the quick start in powershell will result otherwise in the utf-8 BOM  (Byte Order Mark) being added 

```
SyntaxError: Unexpected character '�'. (1:0) in src/hello.stories.tsx

> 1 | ��export const World = () => <p>Hey</p>;
  2 |
  3 |
  ```