### PR TITLE
Fix mdx code blocks throwing errors in dev console

### DIFF
--- a/.changeset/grumpy-seas-drum.md
+++ b/.changeset/grumpy-seas-drum.md
@@ -1,0 +1,6 @@
+---
+"@ladle/react": patch
+"test-addons": patch
+---
+
+Fix mdx code blocks throwing errors in dev console

--- a/e2e/addons/tests/docs.spec.ts
+++ b/e2e/addons/tests/docs.spec.ts
@@ -14,3 +14,14 @@ test("mdx readme is rendered", async ({ page }) => {
     i++;
   }
 });
+
+test("mdx story rendering does not throw errors in console", async ({
+  page,
+}) => {
+  page.on("console", (msg) => {
+    expect(msg.type()).not.toBe("error");
+  });
+
+  await page.goto("/?story=docs--documentation");
+  await expect(page.locator("h1")).toHaveText("test-page");
+});

--- a/packages/ladle/lib/app/src/addons/source.tsx
+++ b/packages/ladle/lib/app/src/addons/source.tsx
@@ -66,7 +66,7 @@ export const CodeHighlight = ({
             {tokens.map((line, i) => (
               <div key={i}>
                 {line.map((token, key) => (
-                  <span key={key} {...getTokenProps({ token, key })} />
+                  <span key={key} {...getTokenProps({ token })} />
                 ))}
               </div>
             ))}


### PR DESCRIPTION
This PR fixes Issue #561, which was quite annoying for us when using ladle in dev mode.
I added a playwright test and ensured that it actually fails without my change.

The change was made according to the prism react renderer documentation (https://www.npmjs.com/package/prism-react-renderer#usage), where there is no key in the getTokenProps function. It seems like this prop is just forwarded.