### PR TITLE
fix: use defaultValue only if value is undefined

### DIFF
--- a/.changeset/tame-crews-sing.md
+++ b/.changeset/tame-crews-sing.md
@@ -1,0 +1,6 @@
+---
+"example": patch
+"@ladle/react": patch
+---
+
+Use defaultValue only if value is undefined

--- a/packages/example/src/controls.stories.tsx
+++ b/packages/example/src/controls.stories.tsx
@@ -37,6 +37,10 @@ Controls.args = {
   colors: ["Red", "Blue"],
 };
 Controls.argTypes = {
+  disabled: {
+    control: { type: "boolean" },
+    defaultValue: true,
+  },
   variant: {
     options: ["primary", "secondary"],
     control: { type: "radio" },

--- a/packages/ladle/lib/app/src/args-provider.tsx
+++ b/packages/ladle/lib/app/src/args-provider.tsx
@@ -107,9 +107,11 @@ const ArgsProvider = ({
           name: argValue.name,
           type: argValue.control.type,
           labels: argValue.control.labels,
-          defaultValue: args[argKey] ? args[argKey] : argValue.defaultValue,
+          defaultValue:
+            args[argKey] === undefined ? argValue.defaultValue : args[argKey],
           options: argValue.options,
-          value: args[argKey] ? args[argKey] : argValue.defaultValue,
+          value:
+            args[argKey] === undefined ? argValue.defaultValue : args[argKey],
           description: argValue.description || argKey,
           min: argValue.control.min,
           max: argValue.control.max,


### PR DESCRIPTION
Added explicit validation for `undefined`, so falsy values (`0`, `false`, `''`, etc.) are not replaced by a default value

See #612