### PR TITLE
Implement Symbol.hasInstance for MockDate

### DIFF
--- a/packages/ladle/lib/app/src/mock-date.ts
+++ b/packages/ladle/lib/app/src/mock-date.ts
@@ -56,6 +56,10 @@ const MockDate = class Date extends RealDate {
 
     return date;
   }
+
+  static [Symbol.hasInstance](instance: unknown): boolean {
+    return instance instanceof RealDate;
+  }
 };
 
 MockDate.UTC = RealDate.UTC;


### PR DESCRIPTION
Hey 👋 

so I'm enjoying use of both: ladle and [date-fns](https://date-fns.org/). And this leads me to a situation where I'm using date-fns `isValid` and `isDate` to check some data. In particular we've got a component that does date based calculations based on a `MockDate`.

My understanding is that date-fns depends on the global Date object in code like this:
```javascript
// node_modules/date-fns/isDate.js
export function isDate(value) {
  return (
    value instanceof Date ||
    (typeof value === "object" &&
      Object.prototype.toString.call(value) === "[object Date]")
  );
}
```

So when calculating new dates we get instances of `RealDate`, and check whether a `RealDate` is `instanceof` a `MockDate`, because `MockDate` rightly replaces the global date when mocking with ladle.

For inheritance this is usually the wrong way: a parent is not an instance of the child class. My suggestions would be to treat it as that though in case of `MockDate` with the following snippet:

```typescript
static [Symbol.hasInstance](instance: unknown): boolean {
    return instance instanceof RealDate;
  }
```
I've tested it by test-wise appending (but not comitting) this code to `packages/ladle/lib/app/src/mock-date.ts`:

```typescript
let d = new RealDate();
let m = new MockDate();

console.log({ l: m, d });

console.table([
  ["d instanceof RealDate", d instanceof RealDate],
  ["m instanceof RealDate", m instanceof RealDate],
  ["m instanceof MockDate", m instanceof MockDate],
  ["d instanceof MockDate", d instanceof MockDate],
]);
```

It leads to output like this:
```
❯ node packages/ladle/lib/app/src/mock-date.ts
{ l: 2025-05-26T15:36:10.887Z, d: 2025-05-26T15:36:10.887Z }
┌─────────┬─────────────────────────┬──────┐
│ (index) │ 0                       │ 1    │
├─────────┼─────────────────────────┼──────┤
│ 0       │ 'd instanceof RealDate' │ true │
│ 1       │ 'm instanceof RealDate' │ true │
│ 2       │ 'm instanceof MockDate' │ true │
│ 3       │ 'd instanceof MockDate' │ true │
└─────────┴─────────────────────────┴──────┘
```