### PR TITLE
fix: add proper types for dialog components

### DIFF
--- a/packages/ladle/lib/app/src/ui.tsx
+++ b/packages/ladle/lib/app/src/ui.tsx
@@ -1,6 +1,27 @@
 import * as React from "react";
-import { DialogOverlay, DialogContent } from "./dialog";
+import {
+  DialogOverlay as RawDialogOverlay,
+  DialogContent as RawDialogContent,
+} from "./dialog";
 import { Close } from "./icons";
+
+// Type definitions for the dialog components from the bundled @reach/dialog
+interface DialogOverlayProps {
+  isOpen?: boolean;
+  onDismiss?: () => void;
+  children?: React.ReactNode;
+  "data-testid"?: string;
+}
+
+interface DialogContentProps {
+  "aria-label"?: string;
+  "data-testid"?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}
+
+const DialogOverlay = RawDialogOverlay as React.FC<DialogOverlayProps>;
+const DialogContent = RawDialogContent as React.FC<DialogContentProps>;
 
 export const Button = ({
   children,
@@ -60,13 +81,11 @@ export const Modal = ({
   maxWidth?: string;
 }) => {
   return (
-    //@ts-ignore
     <DialogOverlay
       isOpen={isOpen}
       onDismiss={() => close()}
       data-testid="ladle-dialog-overlay"
     >
-      {/* @ts-ignore */}
       <DialogContent
         aria-label={label || "Modal"}
         data-testid="ladle-dialog"


### PR DESCRIPTION
having issues with tsgo

```
$ tsgo --noEmit
../../node_modules/@ladle/react/typings-for-build/app/src/ui.tsx:65:7 - error TS2322: Type '{ isOpen: boolean; onDismiss: () => void; "data-testid": string; children: Element; }' is not assignable to type 'IntrinsicAttributes & RefAttributes<unknown>'.
  Property 'isOpen' does not exist on type 'IntrinsicAttributes & RefAttributes<unknown>'.

65       isOpen={isOpen}
         ~~~~~~

../../node_modules/@ladle/react/typings-for-build/app/src/ui.tsx:73:9 - error TS2322: Type '{ "aria-label": string; "data-testid": string; style: { maxWidth: string; }; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & RefAttributes<unknown>'.
  Property 'style' does not exist on type 'IntrinsicAttributes & RefAttributes<unknown>'.

73         style={{ maxWidth }}
           ~~~~~


Found 2 errors in the same file, starting at: ../../node_modules/@ladle/react/typings-for-build/app/src/ui.tsx:65

error Command failed with exit code 2.
```