### PR TITLE
chore: upgrade react-inspector to v9.0.0

### DIFF
--- a/.changeset/upgrade-react-inspector.md
+++ b/.changeset/upgrade-react-inspector.md
@@ -1,0 +1,8 @@
+---
+"@ladle/react": patch
+---
+
+Upgrade react-inspector from v6 to v9
+
+- Update react-inspector dependency to ^9.0.0
+- Change TypeScript moduleResolution from "node" to "bundler" to support modern ESM exports

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -66,7 +66,7 @@
     "prop-types": "^15.8.1",
     "query-string": "^9.1.1",
     "react-hotkeys-hook": "^4.6.1",
-    "react-inspector": "^6.0.2",
+    "react-inspector": "^9.0.0",
     "rehype-class-names": "^2.0.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,8 +471,8 @@ importers:
         specifier: ^4.6.1
         version: 4.6.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-inspector:
-        specifier: ^6.0.2
-        version: 6.0.2(react@19.0.0)
+        specifier: ^9.0.0
+        version: 9.0.0(react@19.0.0)
       rehype-class-names:
         specifier: ^2.0.0
         version: 2.0.0
@@ -7173,10 +7173,10 @@ packages:
       react: '>=0.14.0'
       react-dom: '>=0.14.0'
 
-  react-inspector@6.0.2:
-    resolution: {integrity: sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==}
+  react-inspector@9.0.0:
+    resolution: {integrity: sha512-w/VJucSeHxlwRa2nfM2k7YhpT1r5EtlDOClSR+L7DyQP91QMdfFEDXDs9bPYN4kzP7umFtom7L0b2GGjph4Kow==}
     peerDependencies:
-      react: ^16.8.4 || ^17.0.0 || ^18.0.0
+      react: ^18.0.0 || ^19.0.0
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -17015,7 +17015,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       warning: 4.0.3
 
-  react-inspector@6.0.2(react@19.0.0):
+  react-inspector@9.0.0(react@19.0.0):
     dependencies:
       react: 19.0.0
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- Update react-inspector from ^6.0.2 to ^9.0.0
- Change moduleResolution from "node" to "bundler" in tsconfig.json.
  This is required because react-inspector 9.0.0 uses the modern
  `exports` field in package.json, which the legacy "node" resolution
  doesn't understand. The "bundler" setting is the recommended
  configuration for Vite projects.

Closes #597 