### PR TITLE
fix(parse): unwrap TSSatisfiesExpression in named-identifier default-export init

### DIFF
--- a/.changeset/parse-tssatisfies-named-default-export.md
+++ b/.changeset/parse-tssatisfies-named-default-export.md
@@ -1,0 +1,19 @@
+---
+"@ladle/react": patch
+---
+
+fix(parse): unwrap `TSSatisfiesExpression` / `TSAsExpression` in named-identifier default-export init
+
+Ladle's `getDefaultExport` walker handles `TSSatisfiesExpression` / `TSAsExpression` when the _direct declaration_ is wrapped, e.g. `export default { … } satisfies Meta<…>;`. It did not unwrap the same expression when it appears as the **init** of a named identifier that is then re-exported by name:
+
+```ts
+const meta = {
+  title: "Components/Button",
+  component: Button,
+} satisfies Meta<typeof Button>;
+export default meta;
+```
+
+`objNode` ended up pointing at the `TSSatisfiesExpression` rather than the underlying `ObjectExpression`. The subsequent `objNode.properties.forEach` iterated over an empty array (the satisfies node has no `.properties`), so the `title` and `meta` fields silently never reached the result, and story files using this pattern were dropped from the index entirely.
+
+Mirrors the existing direct-declaration unwrap pattern. Adds two new unit tests covering `satisfies` and `as` in this position.

--- a/packages/ladle/lib/cli/vite-plugin/parse/get-default-export.js
+++ b/packages/ladle/lib/cli/vite-plugin/parse/get-default-export.js
@@ -19,6 +19,19 @@ const getDefaultExport = (result, astPath) => {
     ) {
       objNode = astPath.node.declaration.expression;
     }
+    // Unwrap TSSatisfiesExpression / TSAsExpression that appears as the *init*
+    // of a named identifier default-export, e.g.
+    //   const meta = { ... } satisfies Meta<typeof X>;
+    //   export default meta;
+    // The named-identifier branch above resolves `objNode` to the init
+    // expression, but does not strip the `satisfies` wrapper.
+    if (
+      objNode &&
+      (objNode.type === "TSAsExpression" ||
+        objNode.type === "TSSatisfiesExpression")
+    ) {
+      objNode = objNode.expression;
+    }
     objNode &&
       objNode.properties.forEach((/** @type {any} */ prop) => {
         if (prop.type === "ObjectProperty" && prop.key.name === "title") {

--- a/packages/ladle/tests/parse/get-default-export.test.ts
+++ b/packages/ladle/tests/parse/get-default-export.test.ts
@@ -80,3 +80,43 @@ test("Throw an error if default export is not serializable", async () => {
     `Can't parse the default title and meta of file.js. Meta must be serializable and title a string literal.`,
   );
 });
+
+test("Get default export through named identifier with `satisfies`", async () => {
+  // CSF v3 / Storybook style:
+  //   const meta = { ... } satisfies Meta<typeof X>;
+  //   export default meta;
+  // Without the unwrap, `objNode` lands on the TSSatisfiesExpression
+  // (whose `.properties` is undefined), so title and meta silently never
+  // reach the result.
+  expect(
+    parseWithFn(
+      `const meta = { title: 'Title', meta: { some: 'foo' } } satisfies SomeType;
+       export default meta;`,
+      {},
+      getDefaultExport,
+      "ExportDefaultDeclaration",
+      "foo.stories.tsx",
+    ),
+  ).toEqual(
+    getOutput({
+      exportDefaultProps: { title: "Title", meta: { some: "foo" } },
+    }),
+  );
+});
+
+test("Get default export through named identifier with `as`", async () => {
+  expect(
+    parseWithFn(
+      `const meta = { title: 'Title', meta: { flag: true } } as SomeType;
+       export default meta;`,
+      {},
+      getDefaultExport,
+      "ExportDefaultDeclaration",
+      "foo.stories.tsx",
+    ),
+  ).toEqual(
+    getOutput({
+      exportDefaultProps: { title: "Title", meta: { flag: true } },
+    }),
+  );
+});


### PR DESCRIPTION
### Background

Modern Storybook codebases use the [`satisfies`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) operator to attach the `Meta<typeof X>` type to a story's `meta` object while still allowing TypeScript to widen `meta.component` to its actual type:

```ts
const meta = {
  title: "Components/Button",
  component: Button,
} satisfies Meta<typeof Button>;
export default meta;
```

Ladle's `getDefaultExport` walker handles `TSSatisfiesExpression` / `TSAsExpression` when the *direct declaration* is wrapped, e.g. `export default { … } satisfies Meta<…>;`. But it does not unwrap the same expression when it appears as the **init** of a named identifier that is then re-exported by name (the snippet above).

Effect: `objNode` ends up pointing at the `TSSatisfiesExpression` node rather than the underlying `ObjectExpression`. The subsequent `objNode.properties.forEach` walks an empty array (the satisfies node has no `.properties`), so the `title` and `meta` fields silently never reach the result. Story files using this pattern are dropped from the index — Ladle reports `0` stories indexed when the codebase has hundreds, with no error or warning.

Verified in a 312-story production codebase. Without the patch: 0/312 indexed. With: 312/312.

### Change

`packages/ladle/lib/cli/vite-plugin/parse/get-default-export.js`: after resolving a named identifier to its init expression, also unwrap `TSAsExpression` / `TSSatisfiesExpression`. Mirrors the existing handling for the direct-declaration case at the same site.

Three lines of logic, ~12 LOC including the explanatory comment.

### Test plan

- [x] Two new unit tests in `packages/ladle/tests/parse/get-default-export.test.ts`:
  - `Get default export through named identifier with `satisfies``
  - `Get default export through named identifier with `as``
- [x] Both tests fail without the fix with the exact production-observed error: `"Can't parse the default title and meta of file.js. Meta must be serializable and title a string literal."`. Both pass with the fix applied.
- [x] All existing parser tests continue to pass (`pnpm --filter @ladle/react test` — 9 suites / 58 tests, up from 56).
- [x] `pnpm typecheck` and `pnpm lint` clean.

### Reviewer notes

The fix mirrors the existing direct-declaration unwrap (the `if ([…].includes(astPath.node.declaration.type))` block four lines above). Pattern symmetry: every place where Ladle resolves the "default-exported object", strip the `satisfies` / `as` wrapper.

No public API change; pure parser robustness improvement.

Optional follow-up: extract the unwrap into a helper (e.g. `unwrapTsTypeAssertions(node)`) to centralise the "resolve to ObjectExpression" rules and prevent the next site from drifting again. Not done in this PR to keep the diff minimal.

### Out of scope

- The CSF v3 runtime support in `composeEnhancers` (separate PR).
