### PR TITLE
chore: add changeset for #626 (dialog component types)

### DIFF
--- a/.changeset/proper-dialog-component-types.md
+++ b/.changeset/proper-dialog-component-types.md
@@ -1,0 +1,14 @@
+---
+"@ladle/react": patch
+---
+
+fix: add proper types for dialog components
+
+Adds explicit prop types for `DialogOverlay` and `DialogContent` and removes
+the `@ts-ignore` directives in the `Modal` component (the
+[#626](https://github.com/tajo/ladle/pull/626) change). This unblocks
+downstream consumers running stricter typecheckers — notably
+[`@typescript/native-preview` (tsgo)](https://www.npmjs.com/package/@typescript/native-preview),
+which surfaces the underlying `Property 'isOpen' does not exist on type
+'IntrinsicAttributes & RefAttributes<unknown>'` error from
+`typings-for-build/app/src/ui.tsx` even with `skipLibCheck: true`.


### PR DESCRIPTION
## Summary

Adds the missing changeset for #626 ("fix: add proper types for dialog components", merged 2025-12-20 as commit 8cf3226), so the patch can ship in the next release.

The fix is on `main` but isn't in any published version (`5.1.1` and the latest `next` build both predate it), which means downstream consumers still hit the underlying type error in `typings-for-build/app/src/ui.tsx`. In particular, [`@typescript/native-preview` (tsgo)](https://www.npmjs.com/package/@typescript/native-preview) reports it from `node_modules` even with `skipLibCheck: true` — the `@ts-ignore` directives that #626 removed weren't enough on the new compiler.

No code changes — just the missing `.changeset/*.md` file that #626 forgot to include, so the next Version Packages run picks it up.