### PR TITLE
chore: Vite 8 follow-up cleanup (native tsconfig paths + oxc transform)

### DIFF
--- a/.changeset/spicy-points-rest.md
+++ b/.changeset/spicy-points-rest.md
@@ -1,0 +1,5 @@
+---
+"@ladle/react": patch
+---
+
+Vite 8 follow-up cleanup: resolve `tsconfig.json` paths via Vite's native `resolve.tsconfigPaths` option (dropping the `vite-tsconfig-paths` dependency) and migrate the MDX plugin from the deprecated `transformWithEsbuild` to `transformWithOxc`.

--- a/packages/ladle/lib/cli/vite-base.js
+++ b/packages/ladle/lib/cli/vite-base.js
@@ -3,7 +3,6 @@ import react from "@vitejs/plugin-react-swc";
 import fs from "fs";
 import { globby } from "globby";
 import { fileURLToPath } from "url";
-import tsconfigPaths from "vite-tsconfig-paths";
 import getAppRoot from "./get-app-root.js";
 import ladlePlugin from "./vite-plugin/vite-plugin.js";
 import debug from "./debug.js";
@@ -103,6 +102,13 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
     };
   }
 
+  // Vite 8 resolves tsconfig `paths` natively, so we no longer need the
+  // vite-tsconfig-paths plugin. Skip it under Yarn PnP (unsupported) or when
+  // the user already provides their own tsconfig paths plugin.
+  if (!hasTSConfigPathPlugin && !process.versions.pnp) {
+    resolve.tsconfigPaths = true;
+  }
+
   const storyEntries = (
     await globby(
       Array.isArray(ladleConfig.stories)
@@ -155,7 +161,7 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
         ...(ladleConfig.addons.msw.enabled ? ["msw"] : []),
         ...(ladleConfig.addons.msw.enabled ? ["msw/browser"] : []),
         ...(inladleMonorepo ? [] : ["@ladle/react"]),
-        ...(!!resolve.alias ? [] : ["react-dom/client"]),
+        ...(resolve.alias ? [] : ["react-dom/client"]),
       ],
       entries: [
         path.join(process.cwd(), ".ladle/components.js"),
@@ -167,11 +173,6 @@ const getBaseViteConfig = async (ladleConfig, configFolder, viteConfig) => {
     },
     plugins: [
       mdxPlugin({ mode: viteConfig.mode || "production" }),
-      !hasTSConfigPathPlugin &&
-        !process.versions.pnp &&
-        tsconfigPaths({
-          root: process.cwd(),
-        }),
       ladlePlugin(ladleConfig, configFolder, viteConfig.mode || ""),
       !hasReactPlugin && !hasReactSwcPlugin && react(),
     ],

--- a/packages/ladle/lib/cli/vite-plugin/mdx-plugin.js
+++ b/packages/ladle/lib/cli/vite-plugin/mdx-plugin.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { SourceMapGenerator } from "source-map";
-import { transformWithEsbuild } from "vite";
+import { transformWithOxc } from "vite";
 import { VFile } from "vfile";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
@@ -99,8 +99,8 @@ function mdxPlugin(opts) {
         // just using esbuild to compile JSX away
         if (!isDev) {
           return (
-            await transformWithEsbuild(code, filepath.replace(".mdx", ".jsx"), {
-              jsx: "automatic",
+            await transformWithOxc(code, filepath.replace(".mdx", ".jsx"), {
+              jsx: { runtime: "automatic" },
             })
           ).code;
         }
@@ -114,7 +114,11 @@ function mdxPlugin(opts) {
             `You need to install and use @vitejs/plugin-react-swc or @vitejs/plugin-react so ${filename} can be compiled.`,
           );
         }
-        const transformed = await transformWithEsbuild(code, filename);
+        // Match the previous esbuild default (classic runtime) so the output
+        // stays identical for the @vitejs/plugin-react (babel) pipeline.
+        const transformed = await transformWithOxc(code, filename, {
+          jsx: { runtime: "classic" },
+        });
         if (reactPluginTransform) {
           return await reactPluginTransform(
             transformed.code,

--- a/packages/ladle/package.json
+++ b/packages/ladle/package.json
@@ -72,8 +72,7 @@
     "remark-gfm": "^4.0.0",
     "source-map": "^0.7.4",
     "vfile": "^6.0.3",
-    "vite": "^8.0.14",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite": "^8.0.14"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/website/docs/config.md
+++ b/packages/website/docs/config.md
@@ -16,7 +16,8 @@ Ladle does not require any configuration and some features can be controlled thr
 - The parameter `root` is replaced so Ladle can function properly.
 - [`server.port`](https://vitejs.dev/config/#server-port) and [`build.outDir`](https://vitejs.dev/config/#build-outdir) are overridden by Ladle as well, so they can be configured separately from your main project since you probably don't want them to clash.
 - Vite config assumes that paths are relative to the project root; however, Ladle's root is buried in `node_modules`. You should always use absolute paths. Ladle tries to resolve relative paths relative to the project root but that doesn't work when configuring custom plugins for example.
-- Ladle adds [@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) and [vite-tsconfig-paths](https://www.npmjs.com/package/vite-tsconfig-paths) plugins by default. If you need to customize them (for example adding babel presets into the React plugin), you can add them for yourself and Ladle will use yours.
+- Ladle adds the [@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) plugin by default. If you need to customize it (for example adding babel presets into the React plugin), you can add it for yourself and Ladle will use yours.
+- Ladle enables Vite's native [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options.html#resolve-tsconfigpaths) so `paths` from your `tsconfig.json` are resolved automatically (previously handled via the `vite-tsconfig-paths` plugin). It is skipped under Yarn PnP or when you already supply your own tsconfig paths plugin.
 
 ## `.ladle/config.mjs`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,9 +491,6 @@ importers:
       vite:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@22.19.19)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1)
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.2)(vite@8.0.14(@types/node@22.19.19)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1))
     devDependencies:
       '@babel/cli':
         specifier: ^7.26.4
@@ -4930,9 +4927,6 @@ packages:
     resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
     engines: {node: '>=18'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -8153,16 +8147,6 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  tsconfck@3.1.4:
-    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -8426,14 +8410,6 @@ packages:
     resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
-
-  vite-tsconfig-paths@5.1.4:
-    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
@@ -14447,8 +14423,6 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.1.0
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   got@12.6.1:
@@ -18288,10 +18262,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.4(typescript@5.7.2):
-    optionalDependencies:
-      typescript: 5.7.2
-
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
@@ -18574,17 +18544,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vite-tsconfig-paths@5.1.4(typescript@5.7.2)(vite@8.0.14(@types/node@22.19.19)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1)):
-    dependencies:
-      debug: 4.4.0
-      globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@5.7.2)
-    optionalDependencies:
-      vite: 8.0.14(@types/node@22.19.19)(jiti@2.4.2)(terser@5.37.0)(yaml@2.6.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@5.4.11(@types/node@22.19.19)(lightningcss@1.32.0)(terser@5.37.0):
     dependencies:


### PR DESCRIPTION
Follow-up cleanup for the Vite 8 upgrade (#635), addressing two items raised in review/runtime warnings.

## 1. Native tsconfig `paths` resolution
Vite 8 resolves `tsconfig.json` `paths` natively, and it now logs a runtime warning when it detects the `vite-tsconfig-paths` plugin. This switches Ladle to Vite's built-in [`resolve.tsconfigPaths`](https://vite.dev/config/shared-options.html#resolve-tsconfigpaths) option and drops the `vite-tsconfig-paths` dependency.

- Same guards preserved: skipped under Yarn PnP, and skipped when the user already supplies their own tsconfig-paths plugin (`hasTSConfigPathPlugin`).
- Covered by the existing `e2e/config-ts` `paths.spec.ts` test (imports via the `@/` alias), which passes in both dev and prod.

This resolves the question @stevematney raised in #635.

## 2. `transformWithEsbuild` → `transformWithOxc`
Vite 8 deprecates `transformWithEsbuild` (`will be removed in the future. Please migrate to transformWithOxc`). The MDX plugin now uses `transformWithOxc`.

- Prod path uses the automatic runtime (`jsx: { runtime: "automatic" }`), matching the previous `{ jsx: "automatic" }`.
- The dev (babel) path pins the **classic** runtime (`jsx: { runtime: "classic" }`) because that's what esbuild emitted by default — verified the oxc output is byte-identical, so the `@vitejs/plugin-react` pipeline is unaffected. (oxc defaults to `automatic`, which broke MDX dev rendering until pinned.)

## Verification
`pnpm typecheck`, `pnpm lint`, `pnpm build`, and the full `pnpm test` suite (16/16 tasks, incl. babel + swc MDX in dev & prod, and tsconfig-paths) all pass locally on Node 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)