### PR TITLE
ci: migrate release to npm Trusted Publishing (OIDC) + GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,19 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
 
@@ -29,18 +37,14 @@ jobs:
         with:
           node-version: 24.x
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted Publishing (OIDC) needs npm >= 11.5.1; the runner's bundled npm may be older.
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            email=vojtech@miksu.cz
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -48,10 +52,7 @@ jobs:
         with:
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GIT_DEPLOY_KEY }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Publishing next version
         run: cd packages/ladle && pnpm types && ./publish-next.js
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removes the two long-lived secrets from the release pipeline.

## npm: `NPM_TOKEN` → Trusted Publishing (OIDC)
- Drop the hand-written `~/.npmrc` step and `NPM_TOKEN` from both publish steps.
- Publish authenticates via npm Trusted Publishing. The job already declared `id-token: write`, and the trusted publisher for `@ladle/react` is configured on npmjs.com (repo `tajo/ladle` + this workflow file).
- Add `registry-url` and a `npm install -g npm@latest` step — OIDC needs npm ≥ 11.5.1 and the runner's bundled npm can be older. (`changeset publish` and `publish-next.js` both shell out to the system `npm`.)
- Provenance attestations are now generated automatically.

## git: `GIT_DEPLOY_KEY` PAT → GitHub App token
- Replace the personal PAT with a scoped, short-lived installation token via `actions/create-github-app-token@v3`, passed to both `checkout` and `changesets/action`.
- App-token pushes still trigger downstream workflows, so merging the "Version Packages" PR keeps re-triggering the release (the reason the custom PAT existed).

## Secrets
- **Added:** `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY` (already configured).
- **To revoke after the first successful run:** `NPM_TOKEN` (also revoke on npmjs.com) and `GIT_DEPLOY_KEY` (also delete the PAT).

## Rollout / verification
After merge, watch the first release run and confirm:
- [ ] npm publish succeeds via OIDC (provenance shown in the log)
- [ ] the App token opens/updates the Version Packages PR and pushes tags

Only then revoke `NPM_TOKEN` / `GIT_DEPLOY_KEY` — there is no token fallback left in the workflow, so keep them until the first run is green.

Also incidentally resolves the stale `node-version` concern: the job runs on `24.x` (≥ 22.14 required by OIDC, and satisfies root `engines.node >=22.12.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)